### PR TITLE
Add optional position tracking to parser/tokenizer

### DIFF
--- a/lib/ecmarkdown.d.ts
+++ b/lib/ecmarkdown.d.ts
@@ -1,0 +1,369 @@
+declare module "ecmarkdown" {
+    export = ecmarkdown;
+    function ecmarkdown(ecmarkdownText: string): string;
+}
+
+declare module "ecmarkdown/lib/tokenizer" {
+    export = Tokenizer;
+
+    class Tokenizer {
+        constructor(ecmarkdown: string, options?: { trackPositions?: boolean });
+        private _trackPositions;
+        private _eof;
+        private _lookahead;
+        str: string;
+        pos: number;
+        queue: Tokenizer.Token[];
+        previous: Tokenizer.Token;
+        scanDigits(): string;
+        scanWhitespace(): string;
+        scanEscape(): string;
+        scanChars(): string;
+        tryScanTag(): string;
+        tryScanComment(): string;
+        matchToken(): void;
+        enqueueLookahead(tok: Tokenizer.Token, pos: number): void;
+        enqueue(tok: Tokenizer.Token, pos: number): void;
+        dequeue(): Tokenizer.Token;
+        peek(dist?: number): Tokenizer.Token;
+        next(): Tokenizer.Token;
+    }
+
+    namespace Tokenizer {
+        interface EOFToken {
+            name: "EOF";
+            done: true;
+            location?: { pos: number, end: number };
+        }
+
+        type Format = "star" | "underscore" | "tick" | "pipe" | "tilde";
+
+        interface FormatToken {
+            name: Format;
+            contents: string;
+            location?: { pos: number, end: number };
+        }
+
+        interface ParabreakToken {
+            name: "parabreak";
+            contents: string;
+            location?: { pos: number, end: number };
+        }
+
+        interface LinebreakToken {
+            name: "linebreak";
+            contents: string;
+            location?: { pos: number, end: number };
+        }
+
+        interface WhitespaceToken {
+            name: "whitespace";
+            contents: string;
+            location?: { pos: number, end: number };
+        }
+
+        interface TextToken {
+            name: "text";
+            contents: string;
+            location?: { pos: number, end: number };
+        }
+
+        interface CommentToken {
+            name: "comment";
+            contents: string;
+            location?: { pos: number, end: number };
+        }
+
+        interface BlockTagToken {
+            name: "blockTag";
+            contents: string;
+            location?: { pos: number, end: number };
+        }
+
+        interface OpaqueTagToken {
+            name: "opaqueTag";
+            contents: string;
+            location?: { pos: number, end: number };
+        }
+
+        interface TagToken {
+            name: "tag";
+            contents: string;
+            location?: { pos: number, end: number };
+        }
+
+        interface UnorderedListToken {
+            name: "ul";
+            contents: string;
+            location?: { pos: number, end: number };
+        }
+
+        interface OrderedListToken {
+            name: "ol";
+            contents: string;
+            location?: { pos: number, end: number };
+        }
+
+        interface HeaderToken {
+            name: "header";
+            level: number;
+            contents: string;
+            location?: { pos: number, end: number };
+        }
+
+        type Token =
+            | EOFToken
+            | FormatToken
+            | ParabreakToken
+            | LinebreakToken
+            | WhitespaceToken
+            | TextToken
+            | CommentToken
+            | TagToken
+            | UnorderedListToken
+            | OrderedListToken
+            | HeaderToken
+            | BlockTagToken
+            | OpaqueTagToken;
+    }
+}
+
+declare module "ecmarkdown/lib/parser" {
+    import Tokenizer = require("ecmarkdown/lib/tokenizer");
+
+    export = Parser;
+
+    class Parser {
+        constructor(tokenizer: Tokenizer, options?: { trackPositions?: boolean });
+        parseDocument(): Parser.DocumentNode;
+        parseParagraphs(): Parser.ParagraphNode[];
+        parseParagraph(): Parser.ParagraphNode;
+        parseAlgorithm(): Parser.AlgorithmNode;
+        parseList(): Parser.ListNode;
+        parseNonList(): Parser.NonListNode;
+        parseListItem(indent: number): Parser.ListItemNode;
+        parseFragment(inList?: boolean, fmtStack?: Tokenizer.Format[]): Parser.FragmentNode[];
+        parseText(inList: boolean, fmtStack: Tokenizer.Format[]): Parser.TextNode;
+        parseFormat(format: Tokenizer.Format, inList: boolean, fmtStack?: Tokenizer.Format[]): Parser.FragmentNode[];
+        private _t;
+        private _posStack;
+        private pushPos;
+        private popPos;
+        private getPos;
+        private getEnd;
+        private finish;
+    }
+
+    namespace Parser {
+        interface DocumentNode {
+            name: "document";
+            contents: ParagraphNode[];
+            location?: { pos: number, end: number };
+        }
+
+        interface HeaderNode {
+            name: "header";
+            level: number;
+            contents: FragmentNode[];
+            location?: { pos: number, end: number };
+        }
+
+        interface BlockTagNode {
+            name: "blockTag";
+            contents: string;
+            location?: { pos: number, end: number };
+        }
+
+        interface OpaqueTagNode {
+            name: "opaqueTag";
+            contents: string;
+            location?: { pos: number, end: number };
+        }
+
+        interface TagNode {
+            name: "tag";
+            contents: string;
+            location?: { pos: number, end: number };
+        }
+
+        interface CommentNode {
+            name: "comment";
+            contents: string;
+            location?: { pos: number, end: number };
+        }
+
+        interface AlgorithmNode {
+            name: "algorithm";
+            contents: OrderedListNode;
+            location?: { pos: number, end: number };
+        }
+
+        interface TextNode {
+            name: "text";
+            contents: string;
+            location?: { pos: number, end: number };
+        }
+
+        interface StarNode {
+            name: "star";
+            contents: FragmentNode[];
+            location?: { pos: number, end: number };
+        }
+
+        interface UnderscoreNode {
+            name: "underscore";
+            contents: FragmentNode[];
+            location?: { pos: number, end: number };
+        }
+
+        interface TickNode {
+            name: "tick";
+            contents: FragmentNode[];
+            location?: { pos: number, end: number };
+        }
+
+        interface TildeNode {
+            name: "tilde";
+            contents: FragmentNode[];
+            location?: { pos: number, end: number };
+        }
+
+        interface PipeNode {
+            name: "pipe";
+            nonTerminal: string;
+            params: string;
+            optional: boolean;
+            contents: null;
+            location?: { pos: number, end: number };
+        }
+
+        type FormatNode =
+            | StarNode
+            | UnderscoreNode
+            | TickNode
+            | TildeNode
+            | PipeNode;
+
+        interface UnorderedListNode {
+            name: "ul";
+            indent: number;
+            contents: ListItemNode[];
+            location?: { pos: number, end: number };
+        }
+
+        interface OrderedListNode {
+            name: "ol";
+            indent: number;
+            start: number;
+            contents: ListItemNode[];
+            location?: { pos: number, end: number };
+        }
+
+        interface ListItemNode {
+            name: "list-item";
+            contents: ListItemContentNode[];
+            location?: { pos: number, end: number };
+        }
+
+        interface NonListNode {
+            name: "non-list";
+            contents: FragmentNode[];
+            location?: { pos: number, end: number };
+        }
+
+        type ListItemContentNode =
+            | FragmentNode
+            | ListNode;
+
+        type FragmentNode =
+            | TextNode
+            | FormatNode
+            | CommentNode
+            | TagNode;
+
+        type ListNode =
+            | UnorderedListNode
+            | OrderedListNode;
+
+        type ParagraphNode =
+            | HeaderNode
+            | BlockTagNode
+            | OpaqueTagNode
+            | AlgorithmNode
+            | NonListNode
+            | ListNode;
+
+        type Node =
+            | DocumentNode
+            | HeaderNode
+            | BlockTagNode
+            | OpaqueTagNode
+            | TagNode
+            | CommentNode
+            | AlgorithmNode
+            | TextNode
+            | StarNode
+            | UnderscoreNode
+            | TickNode
+            | TildeNode
+            | PipeNode
+            | UnorderedListNode
+            | OrderedListNode
+            | ListItemNode
+            | NonListNode;
+    }
+}
+
+declare module "ecmarkdown/lib/Emitter" {
+    import Parser = require("ecmarkdown/lib/parser");
+
+    export = Emitter;
+
+    abstract class Emitter {
+        str: string;
+        static emit(doc: Parser.DocumentNode): string;
+        emit(node: Parser.Node): string;
+        emitNode(node: Parser.Node): void;
+        abstract emitDocument(node: Parser.DocumentNode): void;
+        abstract emitAlgorithm(node: Parser.AlgorithmNode): void;
+        abstract emitOrderedList(node: Parser.OrderedListNode): void;
+        abstract emitUnorderedList(node: Parser.UnorderedListNode): void;
+        abstract emitListItem(node: Parser.ListItemNode): void;
+        abstract emitText(node: Parser.TextNode): void;
+        abstract emitPipe(node: Parser.PipeNode): void;
+        abstract emitStar(node: Parser.StarNode): void;
+        abstract emitUnderscore(node: Parser.UnderscoreNode): void;
+        abstract emitTick(node: Parser.TickNode): void;
+        abstract emitTilde(node: Parser.TildeNode): void;
+        abstract emitParagraph(node: Parser.NonListNode): void;
+        abstract emitTag(node: Parser.CommentNode | Parser.TagNode | Parser.BlockTagNode | Parser.OpaqueTagNode): void;
+        abstract emitHeader(node: Parser.HeaderNode): void;
+        abstract emitFragment(fragment: Parser.FragmentNode[]): void;
+    }
+}
+
+declare module "ecmarkdown/lib/EcmarkupEmitter" {
+    import Parser = require("ecmarkdown/lib/parser");
+    import Emitter = require("ecmarkdown/lib/Emitter");
+
+    export = EcmarkupEmitter;
+
+    class EcmarkupEmitter extends Emitter {
+        emitDocument(node: Parser.DocumentNode): void;
+        emitAlgorithm(node: Parser.AlgorithmNode): void;
+        emitHeader(node: Parser.HeaderNode): void;
+        emitOrderedList(node: Parser.OrderedListNode): void;
+        emitUnorderedList(node: Parser.UnorderedListNode): void;
+        emitListItem(node: Parser.ListItemNode): void;
+        emitStar(node: Parser.StarNode): void;
+        emitUnderscore(node: Parser.UnderscoreNode): void;
+        emitParagraph(node: Parser.NonListNode): void;
+        emitTag(node: Parser.CommentNode | Parser.TagNode | Parser.BlockTagNode | Parser.OpaqueTagNode): void;
+        emitText(node: Parser.TextNode): void;
+        emitTick(node: Parser.TickNode): void;
+        emitTilde(node: Parser.TildeNode): void;
+        emitFragment(fragment: Parser.FragmentNode[]): void;
+        emitPipe(node: Parser.PipeNode): void;
+        wrapFragment(wrapping: string, fragment: Parser.FragmentNode[]): void;
+    }
+}

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -4,15 +4,17 @@ const escapeHtml = require('escape-html');
 // The `contents` property of a text node is a string. In all other nodes, it's an array.
 
 module.exports = class Parser {
-  constructor(tokenizer) {
+  constructor(tokenizer, options) {
     this._t = tokenizer;
+    this._posStack = options && options.trackPositions ? [] : undefined;
   }
 
   parseDocument() {
+    this.pushPos();
     const document = { name: 'document' };
     document.contents = this.parseParagraphs();
 
-    return document;
+    return this.finish(document);
   }
 
   parseParagraphs() {
@@ -51,15 +53,17 @@ module.exports = class Parser {
     }
 
     if (tok.name === 'header') {
+      this.pushPos();
       this._t.next();
-
-      return { name: 'header', level: tok.level, contents: this.parseFragment({ oneLine: true }) };
+      return this.finish({ name: 'header', level: tok.level, contents: this.parseFragment({ oneLine: true }) });
     } if (tok.name === 'blockTag') {
+      this.pushPos();
       this._t.next();
-      return { name: 'blockTag', contents: tok.contents };
+      return this.finish({ name: 'blockTag', contents: tok.contents });
     } else if (tok.name === 'opaqueTag') {
+      this.pushPos();
       this._t.next();
-      return { name: 'opaqueTag', contents: tok.contents };
+      return this.finish({ name: 'opaqueTag', contents: tok.contents });
     } else if (tok.name === 'ol') {
       return this.parseAlgorithm();
     } else if (tok.name === 'ul') {
@@ -70,12 +74,14 @@ module.exports = class Parser {
   }
 
   parseAlgorithm() {
+    this.pushPos();
     const node = { name: 'algorithm' };
     node.contents = this.parseList();
-    return node;
+    return this.finish(node);
   }
 
   parseList() {
+    this.pushPos();
     const startTok = this._t.peek();
 
     let node;
@@ -103,14 +109,16 @@ module.exports = class Parser {
       node.contents.push(this.parseListItem(node.indent));
     }
 
-    return node;
+    return this.finish(node);
   }
 
   parseNonList() {
-    return { name: 'non-list', contents: this.parseFragment({}) };
+    this.pushPos();
+    return this.finish({ name: 'non-list', contents: this.parseFragment({}) });
   }
 
   parseListItem(indent) {
+    this.pushPos();
     // consume list token
     this._t.next();
 
@@ -128,7 +136,7 @@ module.exports = class Parser {
       }
     }
 
-    return itemNode;
+    return this.finish(itemNode);
   }
 
   parseFragment(opts, fmtStack) {
@@ -163,8 +171,9 @@ module.exports = class Parser {
           frag = frag.concat(node);
         } else {
           // invalid format
-          pushOrJoin(frag, { name: 'text', contents: tok.contents });
+          this.pushPos();
           this._t.next();
+          pushOrJoin(frag, this.finish({ name: 'text', contents: tok.contents }));
         }
       } else if (tok.name === 'comment' || tok.name === 'tag') {
         frag.push(tok);
@@ -173,9 +182,10 @@ module.exports = class Parser {
         if (opts.inList) {
           break;
         } else {
-          pushOrJoin(frag, { name: 'text', contents: tok.contents });
+          this.pushPos();
+          this._t.next();
+          pushOrJoin(frag, this.finish({ name: 'text', contents: tok.contents }));
         }
-        this._t.next();
       } else {
         throw new Error('Unexpected token ' + tok.name);
       }
@@ -188,6 +198,7 @@ module.exports = class Parser {
   // list tokens are considered part of text if we're not in a list
   // format tokens are considered part of text if they're not a valid format
   parseText(opts, fmtStack) {
+    this.pushPos();
     const node = { name: 'text', contents: '' };
 
     while (true) {
@@ -248,7 +259,7 @@ module.exports = class Parser {
       this._t.next();
     }
 
-    return node;
+    return this.finish(node);
   }
 
   parseFormat(format, opts, fmtStack) {
@@ -264,18 +275,19 @@ module.exports = class Parser {
     }
 
     const endTok = this._t.peek();
+    const pos = this.getPos(startTok);
+    const end = this.getPos(endTok);
 
     // fragment ended but we don't have a close format. Convert this node into a text node.
     if (endTok.name !== format) {
-      unshiftOrJoin(node.contents, { name: 'text', contents: startTok.contents });
-
+      unshiftOrJoin(node.contents, this.finish({ name: 'text', contents: startTok.contents }, pos, end));
       return node.contents;
     } else {
       this._t.next(); // consume end format.
 
       if (node.contents.length === 0) {
         // empty formats not allowed
-        return [{ name: 'text', contents: startTok.contents + endTok.contents }];
+        return [this.finish({ name: 'text', contents: startTok.contents + endTok.contents }, pos, end)];
       } else if (node.name === 'tick') {
         node.contents.forEach(function (childNode) {
           if (childNode.name === 'tag') {
@@ -288,17 +300,47 @@ module.exports = class Parser {
 
         if (ntNode === null) {
           // failed to parse a non-terminal, so convert to text.
-          unshiftOrJoin(node.contents, { name: 'text', contents: '|' });
-          pushOrJoin(node.contents, { name: 'text', contents: '|' });
+          const firstPos = this.getPos(node.contents[0]);
+          const lastEnd = this.getEnd(node.contents[node.contents.length - 1]);
+          unshiftOrJoin(node.contents, this.finish({ name: 'text', contents: '|' }, pos, firstPos));
+          pushOrJoin(node.contents, this.finish({ name: 'text', contents: '|' }, lastEnd, end));
 
           return node.contents;
         } else {
-          return [ntNode];
+          return [this.finish(ntNode, pos, end)];
         }
       }
     }
 
-    return [node];
+    return [this.finish(node, pos, end)];
+  }
+
+  pushPos() {
+    if (this._posStack) {
+      this._posStack.push(this.getPos());
+    }
+  }
+
+  popPos() {
+    return this._posStack ? this._posStack.pop() : -1;
+  }
+
+  getPos(node) {
+    if (node === undefined) { node = this._t.peek(); }
+    return this._posStack && node.location ? node.location.pos : -1;
+  }
+
+  getEnd(node) {
+    return this._posStack && node.location ? node.location.end : -1;
+  }
+
+  finish(node, pos, end) {
+    if (pos === undefined) { pos = this.popPos(); }
+    if (end === undefined) { end = this.getPos(); }
+    if (this._posStack) {
+      node.location = { pos, end };
+    }
+    return node;
   }
 };
 
@@ -361,9 +403,8 @@ function unshiftOrJoin(list, node) {
   }
 }
 
-// Parsing of non-terminals, eg. |foo[?Param]_opt|
-// TODO: Rationalize with Grammarkdown (? instead of _opt)
-const nonTerminalRe = /^([A-Za-z0-9]+)(?:\[([^\]]+)\])?(_opt)?$/;
+// Parsing of non-terminals, eg. |foo[?Param]_opt| or |foo[?Param]?|
+const nonTerminalRe = /^([A-Za-z0-9]+)(?:\[([^\]]+)\])?(_opt|\?)?$/;
 function parseNonTerminal(str) {
   const match = str.match(nonTerminalRe);
 

--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -35,8 +35,9 @@ const opaqueTags = new Set([
 ]);
 
 module.exports = class Tokenizer {
-  constructor(str) {
+  constructor(str, options) {
     this.str = str;
+    this._trackPositions = options && options.trackPositions;
     this._eof = false;
     this.pos = 0;
     this.queue = []; // stores tokens when we peek so we don't have to rematch
@@ -88,6 +89,7 @@ module.exports = class Tokenizer {
     let chr;
 
     while (this.pos < len) {
+      const start = this.pos;
       chr = this.str[this.pos];
 
       if (chr === '\\') {
@@ -99,14 +101,14 @@ module.exports = class Tokenizer {
         const tag = this.tryScanTag();
 
         if (tag) {
-          this._lookahead.push({ name: 'tag', contents: tag[0] });
+          this.enqueueLookahead({ name: 'tag', contents: tag[0] }, start);
           break;
         }
 
         const comment = this.tryScanComment();
 
         if (comment) {
-          this._lookahead.push({ name: 'comment', contents: comment });
+          this.enqueueLookahead({ name: 'comment', contents: comment }, start);
           break;
         }
 
@@ -190,7 +192,7 @@ module.exports = class Tokenizer {
     while (true) {
       if (this.pos === str.length) {
         this._eof = true;
-        this.enqueue({ name: 'EOF', done: true });
+        this.enqueue({ name: 'EOF', done: true }, this.pos);
         return;
       }
 
@@ -198,28 +200,29 @@ module.exports = class Tokenizer {
         this._newline = false;
 
         const ws = this.scanWhitespace();
+        const start = this.pos;
 
         if (this.pos >= str.length) {
           if (ws.length > 0) {
-            this.enqueue({ name: 'whitespace', contents: ws });
+            this.enqueue({ name: 'whitespace', contents: ws }, start);
             return;
           }
         } else if (str[this.pos].match(/\d/)) {
           const digits = this.scanDigits();
           if (str[this.pos] === '.' && str[this.pos + 1] === ' ') {
-            this.enqueue({ name: 'ol', contents: ws + digits + '. ' });
             this.pos += 2;
+            this.enqueue({ name: 'ol', contents: ws + digits + '. ' }, start);
             return;
           } else {
             if (ws.length > 0) {
-              this.enqueue({ name: 'whitespace', contents: ws });
+              this.enqueue({ name: 'whitespace', contents: ws }, start);
             }
-            this.enqueue({ name: 'text', contents: digits + this.scanChars() });
+            this.enqueue({ name: 'text', contents: digits + this.scanChars() }, start);
             return;
           }
         } else if (str[this.pos] === '*' && str[this.pos + 1] === ' ') {
-          this.enqueue({ name: 'ul', contents: ws + '* ' });
           this.pos += 2;
+          this.enqueue({ name: 'ul', contents: ws + '* ' }, start);
           return;
         } else if (str[this.pos] === '<') {
           const tag = this.tryScanTag();
@@ -227,16 +230,16 @@ module.exports = class Tokenizer {
           if (tag) {
             if (blockTags.has(tag[1])) {
               const rest = this.scanToEOL();
-              this.enqueue({ name: 'blockTag', contents: ws + tag[0] + rest });
+              this.enqueue({ name: 'blockTag', contents: ws + tag[0] + rest }, start);
               this._newline = true;
             } else if (opaqueTags.has(tag[1]) && tag[2] !== '/') {
               const rest = this.scanToEndTag(tag[1]);
-              this.enqueue({ name: 'opaqueTag', contents: ws + tag[0] + rest });
+              this.enqueue({ name: 'opaqueTag', contents: ws + tag[0] + rest }, start);
             } else {
               if (ws.length > 0) {
-                this.enqueue({ name: 'whitespace', contents: ws });
+                this.enqueue({ name: 'whitespace', contents: ws }, start);
               }
-              this.enqueue({ name: 'tag', contents: tag[0] });
+              this.enqueue({ name: 'tag', contents: tag[0] }, start);
             }
 
             return;
@@ -246,12 +249,11 @@ module.exports = class Tokenizer {
 
           if (comment) {
             const rest = this.scanToEOL();
-            this.enqueue({ name: 'blockTag', contents: ws + comment + rest });
+            this.enqueue({ name: 'blockTag', contents: ws + comment + rest }, start);
             this._newline = true;
             return;
           }
         } else if (str[this.pos] === '#') {
-          const start = this.pos;
           while (this.pos < this.str.length && str[this.pos] === '#') {
             this.pos++;
           }
@@ -259,67 +261,67 @@ module.exports = class Tokenizer {
           const level = this.pos - start;
           if (level > 6 || !isWhitespace(this.str[this.pos])) {
             if (ws.length > 0) {
-              this.enqueue({ name: 'whitespace', contents: ws });
+              this.enqueue({ name: 'whitespace', contents: ws }, start);
             }
 
             // rescan with newline  false
             this.pos = start;
           } else {
-            const tok = { name: 'header', level };
             this.scanWhitespace();
-            tok.contents = ws + this.str.slice(start, this.pos);
-            this.enqueue(tok);
+            const contents = ws + this.str.slice(start, this.pos);
+            this.enqueue({ name: 'header', level, contents }, start);
             return;
           }
         } else if (ws.length > 0) {
-          this.enqueue({ name: 'whitespace', contents: ws });
+          this.enqueue({ name: 'whitespace', contents: ws }, start);
           return;
         }
       }
 
+      const start = this.pos;
       const chr = str[this.pos];
 
       switch (chr) {
-        case '*': this.pos++; this.enqueue({ name: 'star', contents: chr }); return;
-        case '_': this.pos++; this.enqueue({ name: 'underscore', contents: chr }); return;
-        case '`': this.pos++; this.enqueue({ name: 'tick', contents: chr }); return;
-        case '|': this.pos++; this.enqueue({ name: 'pipe', contents: chr }); return;
-        case '~': this.pos++; this.enqueue({ name: 'tilde', contents: chr }); return;
+        case '*': this.pos++; this.enqueue({ name: 'star', contents: chr }, start); return;
+        case '_': this.pos++; this.enqueue({ name: 'underscore', contents: chr }, start); return;
+        case '`': this.pos++; this.enqueue({ name: 'tick', contents: chr }, start); return;
+        case '|': this.pos++; this.enqueue({ name: 'pipe', contents: chr }, start); return;
+        case '~': this.pos++; this.enqueue({ name: 'tilde', contents: chr }, start); return;
         case '\n':
           this._newline = true;
 
           if (str[this.pos + 1] === '\n') {
             this.pos += 2;
-            this.enqueue({ name: 'parabreak', contents: '\n\n' });
+            this.enqueue({ name: 'parabreak', contents: '\n\n' }, start);
           } else {
             this.pos += 1;
-            this.enqueue({ name: 'linebreak', contents: '\n' });
+            this.enqueue({ name: 'linebreak', contents: '\n' }, start);
           }
           return;
         default:
           if (isWhitespace(chr)) {
-            this.enqueue({ name: 'whitespace', contents: this.scanWhitespace() });
+            this.enqueue({ name: 'whitespace', contents: this.scanWhitespace() }, start);
             return;
           } else if (isChars(chr)) {
-            this.enqueue({ name: 'text', contents: this.scanChars() });
+            this.enqueue({ name: 'text', contents: this.scanChars() }, start);
             return;
           } else if (chr === '<') {
             if (this.str[this.pos + 1] === '!' && this.str[this.pos + 2] === '-' && this.str[this.pos + 3] === '-') {
               const comment = this.tryScanComment();
               if (comment) {
-                this.enqueue({ name: 'comment', contents: comment });
+                this.enqueue({ name: 'comment', contents: comment }, start);
                 return;
               }
             } else {
               const tag = this.tryScanTag();
               if (tag) {
-                this.enqueue({ name: 'tag', contents: tag[0] });
+                this.enqueue({ name: 'tag', contents: tag[0] }, start);
                 return;
               }
             }
 
             // didn't find a valid comment or tag, so fall back to text.
-            this.enqueue({ name: 'text', contents: this.scanChars() });
+            this.enqueue({ name: 'text', contents: this.scanChars() }, start);
 
             return;
           } else {
@@ -330,7 +332,13 @@ module.exports = class Tokenizer {
     }
   }
 
-  enqueue(tok) {
+  enqueueLookahead(tok, pos) {
+    this.locate(tok, pos);
+    this._lookahead.push(tok);
+  }
+
+  enqueue(tok, pos) {
+    this.locate(tok, pos);
     this.queue.push(tok);
 
     if (this._lookahead.length === 0) {
@@ -370,6 +378,12 @@ module.exports = class Tokenizer {
       this.dequeue();
     }
     return this.previous;
+  }
+
+  locate(tok, pos) {
+    if (this._trackPositions) {
+      tok.location = { pos, end: this.pos };
+    }
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "3.0.9",
   "description": "A compiler for \"Ecmarkdown\" algorithm shorthand into HTML.",
   "main": "lib/ecmarkdown.js",
+  "types": "lib/ecmarkdown.d.ts",
   "scripts": {
-    "test": "mocha --reporter dot test/tokenizer.js && node test/run-cases.js",
+    "test": "mocha --reporter dot test/tokenizer.js test/parser.js && node test/run-cases.js",
     "lint": "eslint lib && jscs lib && eslint test && jscs test"
   },
   "repository": "domenic/ecmarkdown",
@@ -19,7 +20,8 @@
     "code"
   ],
   "files": [
-    "lib/*.js"
+    "lib/*.js",
+    "lib/*.d.ts"
   ],
   "dependencies": {
     "escape-html": "^1.0.1"

--- a/test/parser.js
+++ b/test/parser.js
@@ -1,0 +1,27 @@
+'use strict';
+const assert = require('assert');
+const Tokenizer = require('../lib/tokenizer.js');
+const Parser = require('../lib/parser.js');
+
+describe('Parser', function () {
+  function assertNode(node, name, location) {
+    assert.equal(node.name, name);
+    assert.deepEqual(node.location, location);
+  }
+  it('tracks positions', function () {
+    const tokenizer = new Tokenizer('1. a\n2. b', { trackPositions: true });
+    const parser = new Parser(tokenizer, { trackPositions: true });
+    const document = parser.parseDocument();
+    assertNode(document, 'document', { pos: 0, end: 9 });
+    const algorithm = document.contents[0];
+    assertNode(algorithm, 'algorithm', { pos: 0, end: 9 });
+    const list = algorithm.contents;
+    assertNode(list, 'ol', { pos: 0, end: 9 });
+    const item0 = list.contents[0];
+    assertNode(item0, 'list-item', { pos: 0, end: 5 });
+    assertNode(item0.contents[0], 'text', { pos: 3, end: 5 });
+    const item1 = list.contents[1];
+    assertNode(item1, 'list-item', { pos: 5, end: 9 });
+    assertNode(item1.contents[0], 'text', { pos: 8, end: 9 });
+  });
+});

--- a/test/tokenizer.js
+++ b/test/tokenizer.js
@@ -9,9 +9,12 @@ const formats = {
   tilde: '~'
 };
 
-function assertTok(tok, name, contents) {
+function assertTok(tok, name, contents, location) {
   assert.equal(tok.name, name);
   assert.equal(tok.contents, contents);
+  if (location) {
+    assert.deepEqual(tok.location, location);
+  }
 }
 
 describe('Tokenizer#peek', function () {
@@ -424,5 +427,13 @@ describe('backslash escapes', function () {
     const t = new Tokenizer('\\a');
     assertTok(t.next(), 'text', '\\a');
     assertTok(t.next(), 'EOF');
+  });
+});
+
+describe('Tokenizer', function () {
+  it('tracks positions', function () {
+    const t = new Tokenizer('1. foo', { trackPositions: true });
+    assertTok(t.next(), 'ol', '1. ', { pos: 0, end: 3 });
+    assertTok(t.next(), 'text', 'foo', { pos: 3, end: 6 });
   });
 });


### PR DESCRIPTION
This adds optional position tracking to tokens/nodes created by ecmarkdown's Parser and Tokenizer. Position information is necessary for reporting errors/finding references in the ecmarkup-vscode extension I've been working on.

This PR also adds TypeScript type information for better intellisense and type checking when compiling ecmarkup or the ecmarkup-vscode extension.