### PR TITLE
docs(README): Prefer `?` for optional nonterminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Inside a paragraph, list item, or header, the following inline formatting elemen
 
 **Spec-level constants** are written as `~x~` and are translated to `<emu-const>x</emu-const>`. Spec-level constants cannot contain tildes.
 
-**Nonterminals** are written as `|x|`, `|x_opt|`, `|x[p]|`, or `|x[p]_opt|`. These are translated, respectively, into `<emu-nt>x</emu-nt>`, `<emu-nt optional>x</emu-nt>`, `<emu-nt params="p">x</emu-nt>`, or `<emu-nt params="p" optional>x</emu-nt>`. Nonterminal names can only be composed of letters and numbers. Params can be composed of anything except a closing square bracket.
+**Nonterminals** are written as `|x|`, `|x?|`, `|x[p]|`, or `|x[p]?|`. These are translated, respectively, into `<emu-nt>x</emu-nt>`, `<emu-nt optional>x</emu-nt>`, `<emu-nt params="p">x</emu-nt>`, or `<emu-nt params="p" optional>x</emu-nt>`. Nonterminal names can only be composed of letters and numbers. Params can be composed of anything except a closing square bracket. It's possible to write `_opt` instead of `?`, e.g.: `|x_opt|` instead of `|x?|` and `|x[p]_opt|` instead of `|x[p]?|`.
 
 All formats can be started following non-alphanumeric and non-whitespace characters and can be ended following any non-whitespace character. The one exception is code formats which can begin and end in any context.  For example, `my_SIMD_constructor` does not contain any variables while `_SIMD_Constructor` does.
 


### PR DESCRIPTION
Resolves <https://github.com/bterlson/ecmarkup/issues/122> by&nbsp;documenting the&nbsp;`|x?|` and&nbsp;`|x[p]?|`&nbsp;forms, which&nbsp;I&nbsp;prefer, as&nbsp;`|x_opt|` might&nbsp;be&nbsp;interpreted as&nbsp;<code>|</code><code><var>x_opt</var></code><code>|</code> instead&nbsp;of&nbsp;<code>|</code><code><var>x</var></code><code><sub>_opt</sub></code><code>|</code> by&nbsp;those who&nbsp;aren’t yet&nbsp;familiar with&nbsp;**ecmarkdown**.

The&nbsp;`x?`&nbsp;form is&nbsp;also&nbsp;used in&nbsp;several type&nbsp;systems to&nbsp;denote optional&nbsp;types.

---

review?(@ljharb)