### PR TITLE
Add visitor

### DIFF
--- a/src/ecmarkdown.ts
+++ b/src/ecmarkdown.ts
@@ -1,5 +1,5 @@
 import { Parser } from './parser';
-import { Visitor } from './visitor';
+import { visit } from './visitor';
 import { Emitter } from './emitter';
 
 export type Options = {
@@ -8,7 +8,6 @@ export type Options = {
 
 let parseFragment = Parser.parseFragment;
 let parseAlgorithm = Parser.parseAlgorithm;
-let visit = Visitor.visit;
 let emit = Emitter.emit;
 let fragment = (str: string, options?: Options) => Emitter.emit(Parser.parseFragment(str, options));
 let algorithm = (str: string, options?: Options) =>

--- a/src/ecmarkdown.ts
+++ b/src/ecmarkdown.ts
@@ -1,5 +1,6 @@
-import { Emitter } from './emitter';
 import { Parser } from './parser';
+import { Visitor } from './visitor';
+import { Emitter } from './emitter';
 
 export type Options = {
   trackPositions?: boolean;
@@ -7,9 +8,10 @@ export type Options = {
 
 let parseFragment = Parser.parseFragment;
 let parseAlgorithm = Parser.parseAlgorithm;
+let visit = Visitor.visit;
 let emit = Emitter.emit;
 let fragment = (str: string, options?: Options) => Emitter.emit(Parser.parseFragment(str, options));
 let algorithm = (str: string, options?: Options) =>
   Emitter.emit(Parser.parseAlgorithm(str, options));
 
-export { parseFragment, parseAlgorithm, emit, fragment, algorithm };
+export { parseFragment, parseAlgorithm, visit, emit, fragment, algorithm };

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -28,9 +28,9 @@ export class Emitter {
     return this.str;
   }
 
-  static emit(doc: Node | Node[]) {
+  static emit(node: Node | Node[]) {
     const emitter = new Emitter();
-    return emitter.emit(doc);
+    return emitter.emit(node);
   }
 
   emitNode(node: Node | Node[]) {

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -22,31 +22,19 @@ export type Observer = {
   exit?: (node: Node) => void;
 };
 
-export class Visitor {
-  observer: Observer;
-
-  static visit(ast: Node, observer: Observer) {
-    new Visitor(observer).genericallyVisit(ast);
-  }
-
-  constructor(observer: Observer) {
-    this.observer = observer;
-  }
-
-  genericallyVisit(node: Node) {
-    this.observer.enter?.(node);
+export function visit(node: Node, observer: Observer) {
+  observer.enter?.(node);
+  // @ts-ignore
+  for (let childKey of childKeys[node.name]) {
     // @ts-ignore
-    for (let childKey of childKeys[node.name]) {
-      // @ts-ignore
-      let child: Node | Node[] = node[childKey];
-      if (Array.isArray(child)) {
-        for (let c of child) {
-          this.genericallyVisit(c);
-        }
-      } else {
-        this.genericallyVisit(child);
+    let child: Node | Node[] = node[childKey];
+    if (Array.isArray(child)) {
+      for (let c of child) {
+        visit(c, observer);
       }
+    } else {
+      visit(child, observer);
     }
-    this.observer.exit?.(node);
   }
+  observer.exit?.(node);
 }

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -1,0 +1,52 @@
+import type { Node } from './node-types';
+
+const childKeys = {
+  opaqueTag: [],
+  tag: [],
+  comment: [],
+  algorithm: ['contents'],
+  text: [],
+  star: ['contents'],
+  underscore: ['contents'],
+  tick: ['contents'],
+  tilde: ['contents'],
+  pipe: [],
+  ul: ['contents'],
+  ol: ['contents'],
+  'ordered-list-item': ['contents'],
+  'unordered-list-item': ['contents'],
+};
+
+export type Observer = {
+  enter?: (node: Node) => void;
+  exit?: (node: Node) => void;
+};
+
+export class Visitor {
+  observer: Observer;
+
+  static visit(ast: Node, observer: Observer) {
+    new Visitor(observer).genericallyVisit(ast);
+  }
+
+  constructor(observer: Observer) {
+    this.observer = observer;
+  }
+
+  genericallyVisit(node: Node) {
+    this.observer.enter?.(node);
+    // @ts-ignore
+    for (let childKey of childKeys[node.name]) {
+      // @ts-ignore
+      let child: Node | Node[] = node[childKey];
+      if (Array.isArray(child)) {
+        for (let c of child) {
+          this.genericallyVisit(c);
+        }
+      } else {
+        this.genericallyVisit(child);
+      }
+    }
+    this.observer.exit?.(node);
+  }
+}


### PR DESCRIPTION
This adds a basic visitor under `visitor.ts`. ~It also splits the ordered and unordered list item types and prevents parsing lists which mix the two (which was presumably a bug, though I haven't added a test).~ Not anymore; apparently that was intentional. Not entirely what we want to do here - probably allow mixing, and lint against it.

~Based on https://github.com/tc39/ecmarkdown/pull/59 and marked as a draft until that PR is landed.~ Edit: ready to go.