### PR TITLE
fix offset for nodes starting with whitespace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ecmarkdown",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecmarkdown",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "A compiler for \"Ecmarkdown\" algorithm shorthand into HTML.",
   "main": "dist/ecmarkdown.js",
   "scripts": {

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -197,8 +197,8 @@ export class Tokenizer {
       if (this._newline) {
         this._newline = false;
 
-        const ws = this.scanWhitespace();
         const start = this.getLocation();
+        const ws = this.scanWhitespace();
 
         if (this.pos >= str.length) {
           if (ws.length > 0) {

--- a/test/parser.js
+++ b/test/parser.js
@@ -9,35 +9,35 @@ describe('Parser', function () {
     assert.deepEqual(node.location, location);
   }
   it('tracks positions', function () {
-    const tokenizer = new Tokenizer('1. a\n2. b c', { trackPositions: true });
+    const tokenizer = new Tokenizer('  1. a\n  2. b c', { trackPositions: true });
     const parser = new Parser(tokenizer, { trackPositions: true });
     const algorithm = parser.parseAlgorithm();
     assertNode(algorithm, 'algorithm', {
       start: { line: 1, column: 0, offset: 0 },
-      end: { line: 2, column: 6, offset: 11 },
+      end: { line: 2, column: 8, offset: 15 },
     });
     const list = algorithm.contents;
     assertNode(list, 'ol', {
       start: { line: 1, column: 0, offset: 0 },
-      end: { line: 2, column: 6, offset: 11 },
+      end: { line: 2, column: 8, offset: 15 },
     });
     const item0 = list.contents[0];
     assertNode(item0, 'ordered-list-item', {
       start: { line: 1, column: 0, offset: 0 },
-      end: { line: 2, column: 0, offset: 5 },
+      end: { line: 2, column: 0, offset: 7 },
     });
     assertNode(item0.contents[0], 'text', {
-      start: { line: 1, column: 3, offset: 3 },
-      end: { line: 1, column: 4, offset: 4 },
+      start: { line: 1, column: 5, offset: 5 },
+      end: { line: 1, column: 6, offset: 6 },
     });
     const item1 = list.contents[1];
     assertNode(item1, 'ordered-list-item', {
-      start: { line: 2, column: 0, offset: 5 },
-      end: { line: 2, column: 6, offset: 11 },
+      start: { line: 2, column: 0, offset: 7 },
+      end: { line: 2, column: 8, offset: 15 },
     });
     assertNode(item1.contents[0], 'text', {
-      start: { line: 2, column: 3, offset: 8 },
-      end: { line: 2, column: 6, offset: 11 },
+      start: { line: 2, column: 5, offset: 12 },
+      end: { line: 2, column: 8, offset: 15 },
     });
   });
 });


### PR DESCRIPTION
Previously the offset for tokens beginning with whitespace pointed to the position after the whitespace, even though the whitespace was included in the token's contents. This also meant the column did not match the offset.

Includes version bump commit, so please **rebase**, not squash.