### PR TITLE
support for labeling steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Lists are written as a series of lines, each starting with either a number, e.g.
 
 Lists can be nested. To do so, use any number of spaces to indent; as long as the number of spaces is consistent, list items will stay together in a nested list.
 
+List items can be given a label by putting `[label="something"]` at the start of the item, as in `1. [label="something"]`. This will generate a `<li>` element with an id property of `step-something` or `item-something` for ordered and unordered lists respectively. This is used by Ecmarkup for referencing specific steps of Ecmarkdown algorithms.
+
 #### HTML Blocks
 
 Any line which starts with a block-level HTML tag ([as defined by CommonMark](http://spec.commonmark.org/0.22/#html-blocks), with the addition of `<emu-note>`, `<emu-clause>`, `<emu-intro>`, `<emu-annex>`, `<emu-biblio>`, `<emu-import>`, `<emu-table>`, `<emu-figure>`, `<emu-example>`, `<emu-alg>`, and `<emu-see-also-para>`) is a HTML block line. Ecmarkdown cannot be used on the line starting a HTML block, but subsequent lines before the closing tag do allow it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ecmarkdown",
-  "version": "5.0.2",
+  "version": "5.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecmarkdown",
-  "version": "5.0.2",
+  "version": "5.1.0",
   "description": "A compiler for \"Ecmarkdown\" algorithm shorthand into HTML.",
   "main": "dist/ecmarkdown.js",
   "scripts": {

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -104,7 +104,11 @@ export class Emitter {
   }
 
   emitListItem(li: OrderedListItemNode | UnorderedListItemNode) {
-    this.str += '<li>';
+    let label =
+      li.label === null
+        ? ''
+        : ` id="${li.name === 'ordered-list-item' ? 'step' : 'item'}-${li.label}"`;
+    this.str += `<li${label}>`;
     this.emitFragment(li.contents);
     if (li.sublist !== null) {
       if (li.sublist.name === 'ol') {

--- a/src/node-types.ts
+++ b/src/node-types.ts
@@ -77,6 +77,12 @@ export type OrderedListToken = {
   location?: LocationRange;
 };
 
+export type LabelToken = {
+  name: 'label';
+  value: string;
+  location?: LocationRange;
+};
+
 export type Token =
   | EOFToken
   | FormatToken
@@ -176,6 +182,7 @@ export type UnorderedListItemNode = {
   name: 'unordered-list-item';
   contents: FragmentNode[];
   sublist: ListNode | null;
+  label: string | null;
   location?: LocationRange;
 };
 
@@ -183,6 +190,7 @@ export type OrderedListItemNode = {
   name: 'ordered-list-item';
   contents: FragmentNode[];
   sublist: ListNode | null;
+  label: string | null;
   location?: LocationRange;
 };
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -121,6 +121,8 @@ export class Parser {
     // consume list token
     this._t.next();
 
+    const label = this._t.tryScanLabel();
+
     const contents: FragmentNode[] = this.parseFragment({ inList: true });
 
     const listItemTok = this._t.peek();
@@ -137,7 +139,7 @@ export class Parser {
 
     let name: 'ordered-list-item' | 'unordered-list-item' =
       kind === 'ol' ? 'ordered-list-item' : 'unordered-list-item';
-    return this.finish({ name, contents, sublist });
+    return this.finish({ name, contents, sublist, label });
   }
 
   parseFragment(opts: ParseFragmentOpts): FragmentNode[];

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -4,6 +4,7 @@ import type { Options } from './ecmarkdown';
 
 const tagRegexp = /^<[/!]?(\w[\w-]*)(\s+[\w]+(\s*=\s*("[^"]*"|'[^']*'|[^><"'=``]+))?)*\s*>/;
 const commentRegexp = /^<!--[\w\W]*?-->/;
+const labelRegexp = /^\[label="([\w-]+)"] /;
 const digitRegexp = /\d/;
 
 const opaqueTags = new Set(['emu-grammar', 'emu-production', 'pre', 'code', 'script', 'style']);
@@ -181,6 +182,18 @@ export class Tokenizer {
     this.pos += match[0].length;
 
     return match[0];
+  }
+
+  // Label tokens are only valid immediately after list tokens, so we let this be called by the parser.
+  tryScanLabel() {
+    const match = this.str.slice(this.pos).match(labelRegexp);
+    if (!match) {
+      return null;
+    }
+
+    this.pos += match[0].length;
+
+    return match[1];
   }
 
   // Attempts to match any of the tokens at the given index of str

--- a/test/cases/list-label.ecmarkdown
+++ b/test/cases/list-label.ecmarkdown
@@ -1,0 +1,8 @@
+1. [label="foo"] Item
+1. Item
+1. Item
+  1. [label="bar"] Item
+  1. Item
+1. Item
+  * Unordered item
+  * [label="baz"] Unordered item

--- a/test/cases/list-label.html
+++ b/test/cases/list-label.html
@@ -1,0 +1,16 @@
+<ol>
+  <li id="step-foo">Item</li>
+  <li>Item</li>
+  <li>Item
+    <ol>
+      <li id="step-bar">Item</li>
+      <li>Item</li>
+    </ol>
+  </li>
+  <li>Item
+    <ul>
+      <li>Unordered item</li>
+      <li id="item-baz">Unordered item</li>
+    </ul>
+  </li>
+</ol>

--- a/test/run-cases.js
+++ b/test/run-cases.js
@@ -34,7 +34,7 @@ for (let file of fs.readdirSync(cases)) {
         }
       }
       if (existing === null) {
-        throw new assert.AssertionError(
+        throw new Error(
           `could not find snapshot for ${file}; perhaps you need to regenerate snapshots?`
         );
       }


### PR DESCRIPTION
This introduces the ability to label steps, towards a solution to https://github.com/tc39/ecmarkup/issues/192.

Corresponding upstream ecmarkup PR at https://github.com/tc39/ecmarkup/pull/217. Corresponding upstream ecma262 PRs at https://github.com/tc39/ecma262/pull/2052.

The ecmarkup PR describes how this is intended to be used, and the ecma262 PR shows what that looks like for ecma262 master.

Fixes https://github.com/tc39/ecmarkdown/issues/56.