### PR TITLE
s/label/id/g

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Lists are written as a series of lines, each starting with either a number, e.g.
 
 Lists can be nested. To do so, use any number of spaces to indent; as long as the number of spaces is consistent, list items will stay together in a nested list.
 
-List items can be given a label by putting `[label="something"]` at the start of the item, as in `1. [label="something"]`. This will generate a `<li>` element with an id property of `step-something` or `item-something` for ordered and unordered lists respectively. This is used by Ecmarkup for referencing specific steps of Ecmarkdown algorithms.
+List items can be given a id by putting `[id="something"]` at the start of the item, as in `1. [id="something"]`. This will generate a `<li>` element with an id property of `something`. This is used by Ecmarkup for referencing specific steps of Ecmarkdown algorithms.
 
 #### HTML Blocks
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ecmarkdown",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecmarkdown",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "A compiler for \"Ecmarkdown\" algorithm shorthand into HTML.",
   "main": "dist/ecmarkdown.js",
   "scripts": {

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -104,11 +104,8 @@ export class Emitter {
   }
 
   emitListItem(li: OrderedListItemNode | UnorderedListItemNode) {
-    let label =
-      li.label === null
-        ? ''
-        : ` id="${li.name === 'ordered-list-item' ? 'step' : 'item'}-${li.label}"`;
-    this.str += `<li${label}>`;
+    let id = li.id === null ? '' : ` id="${li.id}"`;
+    this.str += `<li${id}>`;
     this.emitFragment(li.contents);
     if (li.sublist !== null) {
       if (li.sublist.name === 'ol') {

--- a/src/node-types.ts
+++ b/src/node-types.ts
@@ -77,8 +77,8 @@ export type OrderedListToken = {
   location?: LocationRange;
 };
 
-export type LabelToken = {
-  name: 'label';
+export type IdToken = {
+  name: 'id';
   value: string;
   location?: LocationRange;
 };
@@ -182,7 +182,7 @@ export type UnorderedListItemNode = {
   name: 'unordered-list-item';
   contents: FragmentNode[];
   sublist: ListNode | null;
-  label: string | null;
+  id: string | null;
   location?: LocationRange;
 };
 
@@ -190,7 +190,7 @@ export type OrderedListItemNode = {
   name: 'ordered-list-item';
   contents: FragmentNode[];
   sublist: ListNode | null;
-  label: string | null;
+  id: string | null;
   location?: LocationRange;
 };
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -121,7 +121,7 @@ export class Parser {
     // consume list token
     this._t.next();
 
-    const label = this._t.tryScanLabel();
+    const id = this._t.tryScanId();
 
     const contents: FragmentNode[] = this.parseFragment({ inList: true });
 
@@ -139,7 +139,7 @@ export class Parser {
 
     let name: 'ordered-list-item' | 'unordered-list-item' =
       kind === 'ol' ? 'ordered-list-item' : 'unordered-list-item';
-    return this.finish({ name, contents, sublist, label });
+    return this.finish({ name, contents, sublist, id });
   }
 
   parseFragment(opts: ParseFragmentOpts): FragmentNode[];

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -4,7 +4,7 @@ import type { Options } from './ecmarkdown';
 
 const tagRegexp = /^<[/!]?(\w[\w-]*)(\s+[\w]+(\s*=\s*("[^"]*"|'[^']*'|[^><"'=``]+))?)*\s*>/;
 const commentRegexp = /^<!--[\w\W]*?-->/;
-const labelRegexp = /^\[label="([\w-]+)"] /;
+const idRegexp = /^\[id="([\w-]+)"] /;
 const digitRegexp = /\d/;
 
 const opaqueTags = new Set(['emu-grammar', 'emu-production', 'pre', 'code', 'script', 'style']);
@@ -184,9 +184,9 @@ export class Tokenizer {
     return match[0];
   }
 
-  // Label tokens are only valid immediately after list tokens, so we let this be called by the parser.
-  tryScanLabel() {
-    const match = this.str.slice(this.pos).match(labelRegexp);
+  // ID tokens are only valid immediately after list tokens, so we let this be called by the parser.
+  tryScanId() {
+    const match = this.str.slice(this.pos).match(idRegexp);
     if (!match) {
       return null;
     }

--- a/test/cases/list-id.ecmarkdown
+++ b/test/cases/list-id.ecmarkdown
@@ -1,0 +1,8 @@
+1. [id="foo"] Item
+1. Item
+1. Item
+  1. [id="bar"] Item
+  1. Item
+1. Item
+  * Unordered item
+  * [id="baz"] Unordered item

--- a/test/cases/list-id.html
+++ b/test/cases/list-id.html
@@ -1,16 +1,16 @@
 <ol>
-  <li id="step-foo">Item</li>
+  <li id="foo">Item</li>
   <li>Item</li>
   <li>Item
     <ol>
-      <li id="step-bar">Item</li>
+      <li id="bar">Item</li>
       <li>Item</li>
     </ol>
   </li>
   <li>Item
     <ul>
       <li>Unordered item</li>
-      <li id="item-baz">Unordered item</li>
+      <li id="baz">Unordered item</li>
     </ul>
   </li>
 </ol>

--- a/test/cases/list-label.ecmarkdown
+++ b/test/cases/list-label.ecmarkdown
@@ -1,8 +1,0 @@
-1. [label="foo"] Item
-1. Item
-1. Item
-  1. [label="bar"] Item
-  1. Item
-1. Item
-  * Unordered item
-  * [label="baz"] Unordered item


### PR DESCRIPTION
Per discussion with the other ecma262 editors we as a group prefer spelling this as `id="foo"` rather than `label="foo"`, and not prefixing the id attribute in the output.

Includes (patch) version bump commit, so please **rebase**, not squash.