### PR TITLE
fix location for labeled steps

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -40,7 +40,6 @@
   "rules": {
     "prettier/prettier": "error",
     "consistent-return": "off",
-    "no-eq-null": "error",
     "no-floating-decimal": "error",
     "no-self-compare": "error",
     "no-throw-literal": "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ecmarkdown",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecmarkdown",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "A compiler for \"Ecmarkdown\" algorithm shorthand into HTML.",
   "main": "dist/ecmarkdown.js",
   "scripts": {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -139,7 +139,7 @@ export class Parser {
 
     let name: 'ordered-list-item' | 'unordered-list-item' =
       kind === 'ol' ? 'ordered-list-item' : 'unordered-list-item';
-    return this.finish({ name, contents, sublist, id });
+    return this.finish({ name, contents, sublist, id: id == null ? null : id.value });
   }
 
   parseFragment(opts: ParseFragmentOpts): FragmentNode[];

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -1,4 +1,4 @@
-import type { Token, Position } from './node-types';
+import type { Token, IdToken, Position } from './node-types';
 
 import type { Options } from './ecmarkdown';
 
@@ -191,9 +191,14 @@ export class Tokenizer {
       return null;
     }
 
+    const start = this.getLocation();
+
     this.pos += match[0].length;
 
-    return match[1];
+    let token: IdToken = { name: 'id', value: match[1] };
+    this.locate(token, start);
+
+    return token;
   }
 
   // Attempts to match any of the tokens at the given index of str
@@ -404,7 +409,7 @@ export class Tokenizer {
     return this.previous;
   }
 
-  locate(tok: Token, startPos: Position) {
+  locate(tok: Token | IdToken, startPos: Position) {
     if (this._trackPositions) {
       if (tok.name === 'linebreak') {
         this.column = 0;

--- a/test/parser.js
+++ b/test/parser.js
@@ -9,35 +9,35 @@ describe('Parser', function () {
     assert.deepEqual(node.location, location);
   }
   it('tracks positions', function () {
-    const tokenizer = new Tokenizer('  1. a\n  2. b c', { trackPositions: true });
+    const tokenizer = new Tokenizer('  1. [id="thing"] a\n  2. b c', { trackPositions: true });
     const parser = new Parser(tokenizer, { trackPositions: true });
     const algorithm = parser.parseAlgorithm();
     assertNode(algorithm, 'algorithm', {
       start: { line: 1, column: 0, offset: 0 },
-      end: { line: 2, column: 8, offset: 15 },
+      end: { line: 2, column: 8, offset: 28 },
     });
     const list = algorithm.contents;
     assertNode(list, 'ol', {
       start: { line: 1, column: 0, offset: 0 },
-      end: { line: 2, column: 8, offset: 15 },
+      end: { line: 2, column: 8, offset: 28 },
     });
     const item0 = list.contents[0];
     assertNode(item0, 'ordered-list-item', {
       start: { line: 1, column: 0, offset: 0 },
-      end: { line: 2, column: 0, offset: 7 },
+      end: { line: 2, column: 0, offset: 20 },
     });
     assertNode(item0.contents[0], 'text', {
-      start: { line: 1, column: 5, offset: 5 },
-      end: { line: 1, column: 6, offset: 6 },
+      start: { line: 1, column: 18, offset: 18 },
+      end: { line: 1, column: 19, offset: 19 },
     });
     const item1 = list.contents[1];
     assertNode(item1, 'ordered-list-item', {
-      start: { line: 2, column: 0, offset: 7 },
-      end: { line: 2, column: 8, offset: 15 },
+      start: { line: 2, column: 0, offset: 20 },
+      end: { line: 2, column: 8, offset: 28 },
     });
     assertNode(item1.contents[0], 'text', {
-      start: { line: 2, column: 5, offset: 12 },
-      end: { line: 2, column: 8, offset: 15 },
+      start: { line: 2, column: 5, offset: 25 },
+      end: { line: 2, column: 8, offset: 28 },
     });
   });
 });


### PR DESCRIPTION
`tryScanToken` wasn't calling `this.locate`, which is responsible for updating the column, which meant columns were wrong for the text following a label.