### PR TITLE
Always track location information

### DIFF
--- a/src/ecmarkdown.ts
+++ b/src/ecmarkdown.ts
@@ -24,15 +24,10 @@ import { Parser } from './parser';
 import { visit } from './visitor';
 import { Emitter } from './emitter';
 
-export type Options = {
-  trackPositions?: boolean;
-};
-
 let parseFragment = Parser.parseFragment;
 let parseAlgorithm = Parser.parseAlgorithm;
 let emit = Emitter.emit;
-let fragment = (str: string, options?: Options) => Emitter.emit(Parser.parseFragment(str, options));
-let algorithm = (str: string, options?: Options) =>
-  Emitter.emit(Parser.parseAlgorithm(str, options));
+let fragment = (str: string) => Emitter.emit(Parser.parseFragment(str));
+let algorithm = (str: string) => Emitter.emit(Parser.parseAlgorithm(str));
 
 export { parseFragment, parseAlgorithm, visit, emit, fragment, algorithm };

--- a/src/node-types.ts
+++ b/src/node-types.ts
@@ -1,6 +1,8 @@
 // I know this looks like it shouldn't do anything, but it's a workaround for a deficiency of the built-in omit.
 // See https://github.com/microsoft/TypeScript/issues/39556
-export type ActualOmit<T, K extends string> = T extends unknown ? Omit<T, K> : never;
+type ActualOmit<T, K extends string> = T extends unknown ? Omit<T, K> : never;
+
+export type Unlocated<T extends { location: LocationRange }> = ActualOmit<T, 'location'>;
 
 export type Position = {
   line: number;

--- a/src/node-types.ts
+++ b/src/node-types.ts
@@ -1,3 +1,7 @@
+// I know this looks like it shouldn't do anything, but it's a workaround for a deficiency of the built-in omit.
+// See https://github.com/microsoft/TypeScript/issues/39556
+export type ActualOmit<T, K extends string> = T extends unknown ? Omit<T, K> : never;
+
 export type Position = {
   line: number;
   column: number;
@@ -9,13 +13,10 @@ export type LocationRange = {
   end: Position;
 };
 
-export type Located = {
-  location: LocationRange;
-};
-
 export type EOFToken = {
   name: 'EOF';
   done: true;
+  location: LocationRange;
 };
 
 export type Format = 'star' | 'underscore' | 'tick' | 'pipe' | 'tilde';
@@ -23,56 +24,67 @@ export type Format = 'star' | 'underscore' | 'tick' | 'pipe' | 'tilde';
 export type FormatToken = {
   name: Format;
   contents: string;
+  location: LocationRange;
 };
 
 export type ParabreakToken = {
   name: 'parabreak';
   contents: string;
+  location: LocationRange;
 };
 
 export type LinebreakToken = {
   name: 'linebreak';
   contents: string;
+  location: LocationRange;
 };
 
 export type WhitespaceToken = {
   name: 'whitespace';
   contents: string;
+  location: LocationRange;
 };
 
 export type TextToken = {
   name: 'text';
   contents: string;
+  location: LocationRange;
 };
 
 export type CommentToken = {
   name: 'comment';
   contents: string;
+  location: LocationRange;
 };
 
 export type OpaqueTagToken = {
   name: 'opaqueTag';
   contents: string;
+  location: LocationRange;
 };
 
 export type TagToken = {
   name: 'tag';
   contents: string;
+  location: LocationRange;
 };
 
 export type UnorderedListToken = {
   name: 'ul';
   contents: string;
+  location: LocationRange;
 };
 
 export type OrderedListToken = {
   name: 'ol';
   contents: string;
+  location: LocationRange;
 };
 
 export type IdToken = {
   name: 'id';
   value: string;
+  location: LocationRange;
 };
 
 export type Token =
@@ -90,51 +102,58 @@ export type Token =
 
 export type NotEOFToken = Exclude<Token, EOFToken>;
 
-export type LocatedToken = Token & Located;
-
 export type OpaqueTagNode = {
   name: 'opaqueTag';
   contents: string;
+  location: LocationRange;
 };
 
 export type TagNode = {
   name: 'tag';
   contents: string;
+  location: LocationRange;
 };
 
 export type CommentNode = {
   name: 'comment';
   contents: string;
+  location: LocationRange;
 };
 
 export type AlgorithmNode = {
   name: 'algorithm';
   contents: OrderedListNode;
+  location: LocationRange;
 };
 
 export type TextNode = {
   name: 'text';
   contents: string;
+  location: LocationRange;
 };
 
 export type StarNode = {
   name: 'star';
   contents: FragmentNode[];
+  location: LocationRange;
 };
 
 export type UnderscoreNode = {
   name: 'underscore';
   contents: FragmentNode[];
+  location: LocationRange;
 };
 
 export type TickNode = {
   name: 'tick';
   contents: FragmentNode[];
+  location: LocationRange;
 };
 
 export type TildeNode = {
   name: 'tilde';
   contents: FragmentNode[];
+  location: LocationRange;
 };
 
 export type PipeNode = {
@@ -143,6 +162,7 @@ export type PipeNode = {
   params: string;
   optional: boolean;
   contents: null;
+  location: LocationRange;
 };
 
 export type FormatNode = StarNode | UnderscoreNode | TickNode | TildeNode | PipeNode;
@@ -151,6 +171,7 @@ export type UnorderedListNode = {
   name: 'ul';
   indent: number;
   contents: UnorderedListItemNode[];
+  location: LocationRange;
 };
 
 export type OrderedListNode = {
@@ -158,6 +179,7 @@ export type OrderedListNode = {
   indent: number;
   start: number;
   contents: OrderedListItemNode[];
+  location: LocationRange;
 };
 
 export type UnorderedListItemNode = {
@@ -165,6 +187,7 @@ export type UnorderedListItemNode = {
   contents: FragmentNode[];
   sublist: ListNode | null;
   id: string | null;
+  location: LocationRange;
 };
 
 export type OrderedListItemNode = {
@@ -172,6 +195,7 @@ export type OrderedListItemNode = {
   contents: FragmentNode[];
   sublist: ListNode | null;
   id: string | null;
+  location: LocationRange;
 };
 
 export type FragmentNode = TextNode | FormatNode | CommentNode | TagNode | OpaqueTagNode;
@@ -193,5 +217,3 @@ export type Node =
   | OrderedListNode
   | UnorderedListItemNode
   | OrderedListItemNode;
-
-export type LocatedNode = Node & Located;

--- a/src/node-types.ts
+++ b/src/node-types.ts
@@ -9,10 +9,13 @@ export type LocationRange = {
   end: Position;
 };
 
+export type Located = {
+  location: LocationRange;
+};
+
 export type EOFToken = {
   name: 'EOF';
   done: true;
-  location?: LocationRange;
 };
 
 export type Format = 'star' | 'underscore' | 'tick' | 'pipe' | 'tilde';
@@ -20,67 +23,56 @@ export type Format = 'star' | 'underscore' | 'tick' | 'pipe' | 'tilde';
 export type FormatToken = {
   name: Format;
   contents: string;
-  location?: LocationRange;
 };
 
 export type ParabreakToken = {
   name: 'parabreak';
   contents: string;
-  location?: LocationRange;
 };
 
 export type LinebreakToken = {
   name: 'linebreak';
   contents: string;
-  location?: LocationRange;
 };
 
 export type WhitespaceToken = {
   name: 'whitespace';
   contents: string;
-  location?: LocationRange;
 };
 
 export type TextToken = {
   name: 'text';
   contents: string;
-  location?: LocationRange;
 };
 
 export type CommentToken = {
   name: 'comment';
   contents: string;
-  location?: LocationRange;
 };
 
 export type OpaqueTagToken = {
   name: 'opaqueTag';
   contents: string;
-  location?: LocationRange;
 };
 
 export type TagToken = {
   name: 'tag';
   contents: string;
-  location?: LocationRange;
 };
 
 export type UnorderedListToken = {
   name: 'ul';
   contents: string;
-  location?: LocationRange;
 };
 
 export type OrderedListToken = {
   name: 'ol';
   contents: string;
-  location?: LocationRange;
 };
 
 export type IdToken = {
   name: 'id';
   value: string;
-  location?: LocationRange;
 };
 
 export type Token =
@@ -98,58 +90,51 @@ export type Token =
 
 export type NotEOFToken = Exclude<Token, EOFToken>;
 
+export type LocatedToken = Token & Located;
+
 export type OpaqueTagNode = {
   name: 'opaqueTag';
   contents: string;
-  location?: LocationRange;
 };
 
 export type TagNode = {
   name: 'tag';
   contents: string;
-  location?: LocationRange;
 };
 
 export type CommentNode = {
   name: 'comment';
   contents: string;
-  location?: LocationRange;
 };
 
 export type AlgorithmNode = {
   name: 'algorithm';
   contents: OrderedListNode;
-  location?: LocationRange;
 };
 
 export type TextNode = {
   name: 'text';
   contents: string;
-  location?: LocationRange;
 };
 
 export type StarNode = {
   name: 'star';
   contents: FragmentNode[];
-  location?: LocationRange;
 };
 
 export type UnderscoreNode = {
   name: 'underscore';
   contents: FragmentNode[];
-  location?: LocationRange;
 };
 
 export type TickNode = {
   name: 'tick';
   contents: FragmentNode[];
-  location?: LocationRange;
 };
 
 export type TildeNode = {
   name: 'tilde';
   contents: FragmentNode[];
-  location?: LocationRange;
 };
 
 export type PipeNode = {
@@ -158,7 +143,6 @@ export type PipeNode = {
   params: string;
   optional: boolean;
   contents: null;
-  location?: LocationRange;
 };
 
 export type FormatNode = StarNode | UnderscoreNode | TickNode | TildeNode | PipeNode;
@@ -167,7 +151,6 @@ export type UnorderedListNode = {
   name: 'ul';
   indent: number;
   contents: UnorderedListItemNode[];
-  location?: LocationRange;
 };
 
 export type OrderedListNode = {
@@ -175,7 +158,6 @@ export type OrderedListNode = {
   indent: number;
   start: number;
   contents: OrderedListItemNode[];
-  location?: LocationRange;
 };
 
 export type UnorderedListItemNode = {
@@ -183,7 +165,6 @@ export type UnorderedListItemNode = {
   contents: FragmentNode[];
   sublist: ListNode | null;
   id: string | null;
-  location?: LocationRange;
 };
 
 export type OrderedListItemNode = {
@@ -191,7 +172,6 @@ export type OrderedListItemNode = {
   contents: FragmentNode[];
   sublist: ListNode | null;
   id: string | null;
-  location?: LocationRange;
 };
 
 export type FragmentNode = TextNode | FormatNode | CommentNode | TagNode | OpaqueTagNode;
@@ -213,3 +193,5 @@ export type Node =
   | OrderedListNode
   | UnorderedListItemNode
   | OrderedListItemNode;
+
+export type LocatedNode = Node & Located;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,5 +1,5 @@
 import type {
-  ActualOmit,
+  Unlocated,
   LocationRange,
   Position,
   Token,
@@ -84,7 +84,7 @@ export class Parser {
     this.pushPos();
     const startTok = this._t.peek() as OrderedListToken | UnorderedListToken;
 
-    let node: ActualOmit<ListNode, 'location'>;
+    let node: Unlocated<ListNode>;
     if (startTok.name === 'ul') {
       const match = startTok.contents.match(/(\s*)\* /);
       node = { name: 'ul', indent: match![1].length, contents: [] };
@@ -357,7 +357,7 @@ export class Parser {
     return node.location.end;
   }
 
-  finish<T extends ActualOmit<Node, 'location'>>(
+  finish<T extends Unlocated<Node>>(
     node: T,
     start?: Position,
     end?: Position
@@ -440,7 +440,7 @@ function unshiftOrJoin(list: ThingWithContents[], node: ThingWithContents) {
 
 // Parsing of non-terminals, eg. |foo[?Param]_opt| or |foo[?Param]?|
 const nonTerminalRe = /^([A-Za-z0-9]+)(?:\[([^\]]+)\])?(_opt|\?)?$/;
-function parseNonTerminal(str: string): Omit<PipeNode, 'location'> | null {
+function parseNonTerminal(str: string): Unlocated<PipeNode> | null {
   const match = str.match(nonTerminalRe);
 
   if (!match) {

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -1,4 +1,4 @@
-import type { ActualOmit, Token, IdToken, Position } from './node-types';
+import type { Unlocated, Token, IdToken, Position } from './node-types';
 
 const tagRegexp = /^<[/!]?(\w[\w-]*)(\s+[\w]+(\s*=\s*("[^"]*"|'[^']*'|[^><"'=``]+))?)*\s*>/;
 const commentRegexp = /^<!--[\w\W]*?-->/;
@@ -191,7 +191,7 @@ export class Tokenizer {
 
     this.pos += match[0].length;
 
-    let token: Omit<IdToken, 'location'> = { name: 'id', value: match[1] };
+    let token: Unlocated<IdToken> = { name: 'id', value: match[1] };
     this.locate(token, start);
 
     return token;
@@ -359,12 +359,12 @@ export class Tokenizer {
     };
   }
 
-  enqueueLookahead(tok: ActualOmit<Token, 'location'>, pos: Position) {
+  enqueueLookahead(tok: Unlocated<Token>, pos: Position) {
     this.locate(tok, pos);
     this._lookahead.push(tok);
   }
 
-  enqueue(tok: ActualOmit<Token, 'location'>, pos: Position) {
+  enqueue(tok: Unlocated<Token>, pos: Position) {
     this.locate(tok, pos);
     this.queue.push(tok);
 
@@ -407,9 +407,9 @@ export class Tokenizer {
 
   // This is kind of an abuse of "asserts": we're not _asserting_ that `tok` has `location`, but rather arranging that this be so.
   // I don't think TS has a good way to model that, though.
-  locate(tok: ActualOmit<Token, 'location'>, startPos: Position): asserts tok is Token;
-  locate(tok: ActualOmit<IdToken, 'location'>, startPos: Position): asserts tok is IdToken;
-  locate(tok: ActualOmit<Token, 'location'> | ActualOmit<IdToken, 'location'>, startPos: Position) {
+  locate(tok: Unlocated<Token>, startPos: Position): asserts tok is Token;
+  locate(tok: Unlocated<IdToken>, startPos: Position): asserts tok is IdToken;
+  locate(tok: Unlocated<Token | IdToken>, startPos: Position) {
     if (tok.name === 'linebreak') {
       this.column = 0;
       ++this.line;

--- a/test/parser.js
+++ b/test/parser.js
@@ -9,8 +9,8 @@ describe('Parser', function () {
     assert.deepEqual(node.location, location);
   }
   it('tracks positions', function () {
-    const tokenizer = new Tokenizer('  1. [id="thing"] a\n  2. b c', { trackPositions: true });
-    const parser = new Parser(tokenizer, { trackPositions: true });
+    const tokenizer = new Tokenizer('  1. [id="thing"] a\n  2. b c');
+    const parser = new Parser(tokenizer);
     const algorithm = parser.parseAlgorithm();
     assertNode(algorithm, 'algorithm', {
       start: { line: 1, column: 0, offset: 0 },

--- a/test/run-cases.js
+++ b/test/run-cases.js
@@ -23,7 +23,7 @@ for (let file of fs.readdirSync(cases)) {
       let processor = file.endsWith('.fragment.ecmarkdown')
         ? ecmarkdown.fragment
         : ecmarkdown.algorithm;
-      let rawOutput = processor(input, { trackPositions: true });
+      let rawOutput = processor(input);
       let output = beautify(rawOutput);
       let existing = fs.existsSync(snapshotFile) ? fs.readFileSync(snapshotFile, 'utf8') : null;
       if (shouldUpdate) {

--- a/test/tokenizer.js
+++ b/test/tokenizer.js
@@ -415,7 +415,7 @@ describe('backslash escapes', function () {
 
 describe('Tokenizer', function () {
   it('tracks positions', function () {
-    const t = new Tokenizer('1. foo', { trackPositions: true });
+    const t = new Tokenizer('1. foo');
     assertTok(t.next(), 'ol', '1. ', {
       start: { line: 1, column: 0, offset: 0 },
       end: { line: 1, column: 3, offset: 3 },


### PR DESCRIPTION
This simplifies the implementation somewhat (at the expense of some more type juggling and abuses of the type system, sigh). The actual reason I want it is because I want to use location information when reporting parse errors and so need to track it anyway, and I don't see a strong motivate to ever omit it.

This is arguably a breaking change because it drops an option, although code passing that parameter will continue to work and code which does not will work unless it depended on the absence of the `location` field. I'd personally regard it as being minor.

cc @rbuckton in case you're interested.