### PR TITLE
use CLI mocha runner rather than API for snapshots

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "tsc -p src",
     "prepublish": "npm run build",
-    "test": "mocha --reporter dot test/tokenizer.js test/parser.js && node test/run-cases.js",
+    "test": "mocha test/",
+    "rebaseline": "UPDATE_SNAPSHOTS=true npm run test",
     "lint": "eslint --ext .js,.ts src test",
     "format": "prettier --write src test"
   },

--- a/test/run-cases.js
+++ b/test/run-cases.js
@@ -3,20 +3,18 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 const beautify = require('./helpers/beautify.js');
-const Mocha = require('mocha');
 
 const ecmarkdown = require('..');
 
-let shouldUpdate = process.argv.includes('-u') || process.argv.includes('--update');
+let shouldUpdate = process.env.UPDATE_SNAPSHOTS != null;
 
-let mocha = new Mocha();
-let cases = path.resolve(__dirname, 'cases');
-for (let file of fs.readdirSync(cases)) {
-  if (!file.endsWith('.ecmarkdown')) {
-    continue;
-  }
-  mocha.suite.addTest(
-    new Mocha.Test(file, () => {
+describe('baselines', () => {
+  let cases = path.resolve(__dirname, 'cases');
+  for (let file of fs.readdirSync(cases)) {
+    if (!file.endsWith('.ecmarkdown')) {
+      continue;
+    }
+    it(file, () => {
       let snapshotFile = path.resolve(cases, file.replace(/ecmarkdown$/, 'html'));
 
       let input = fs.readFileSync(path.resolve(cases, file), 'utf8');
@@ -39,9 +37,6 @@ for (let file of fs.readdirSync(cases)) {
         );
       }
       assert.strictEqual(existing, output);
-    })
-  );
-}
-mocha.run(failures => {
-  process.exitCode = failures ? 1 : 0;
+    });
+  }
 });

--- a/test/run-cases.js
+++ b/test/run-cases.js
@@ -6,7 +6,7 @@ const beautify = require('./helpers/beautify.js');
 
 const ecmarkdown = require('..');
 
-let shouldUpdate = process.env.UPDATE_SNAPSHOTS != null;
+let shouldUpdate = process.env.UPDATE_SNAPSHOTS === 'true';
 
 describe('baselines', () => {
   let cases = path.resolve(__dirname, 'cases');


### PR DESCRIPTION
Not really sure I used the programmatic API rather than the CLI in https://github.com/tc39/ecmarkdown/pull/61.

This does mean that `npm run test -- -u` no longer works, so I switched to an environment variable (and added an npm script so you wouldn't have to remember that).

Motivation for this change is that I want to add a new test file and didn't want to have to update `package.json` to list it explicitly.