### PR TITLE
switch to one-based column numbers

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -366,7 +366,7 @@ export class Parser {
     let actualEnd: Position =
       end ??
       (this._t.previous === undefined
-        ? { line: 1, column: 0, offset: 0 }
+        ? { line: 1, column: 1, offset: 0 }
         : { ...this._t.previous.location!.end });
     // @ts-ignore
     node.location = { start: actualStart, end: actualEnd };

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -23,7 +23,7 @@ export class Tokenizer {
     this._eof = false;
     this.pos = 0;
     this.line = 1;
-    this.column = 0;
+    this.column = 1;
     this.queue = []; // stores tokens when we peek so we don't have to rematch
 
     this._newline = true;
@@ -411,11 +411,11 @@ export class Tokenizer {
   locate(tok: Unlocated<IdToken>, startPos: Position): asserts tok is IdToken;
   locate(tok: Unlocated<Token | IdToken>, startPos: Position) {
     if (tok.name === 'linebreak') {
-      this.column = 0;
+      this.column = 1;
       ++this.line;
     } else if (tok.name === 'parabreak') {
       let size = tok.contents.length;
-      this.column = 0;
+      this.column = 1;
       this.line += size;
     } else {
       let width = this.pos - startPos.offset;

--- a/test/parser.js
+++ b/test/parser.js
@@ -13,31 +13,31 @@ describe('Parser', function () {
     const parser = new Parser(tokenizer);
     const algorithm = parser.parseAlgorithm();
     assertNode(algorithm, 'algorithm', {
-      start: { line: 1, column: 0, offset: 0 },
-      end: { line: 2, column: 8, offset: 28 },
+      start: { line: 1, column: 1, offset: 0 },
+      end: { line: 2, column: 9, offset: 28 },
     });
     const list = algorithm.contents;
     assertNode(list, 'ol', {
-      start: { line: 1, column: 0, offset: 0 },
-      end: { line: 2, column: 8, offset: 28 },
+      start: { line: 1, column: 1, offset: 0 },
+      end: { line: 2, column: 9, offset: 28 },
     });
     const item0 = list.contents[0];
     assertNode(item0, 'ordered-list-item', {
-      start: { line: 1, column: 0, offset: 0 },
-      end: { line: 2, column: 0, offset: 20 },
+      start: { line: 1, column: 1, offset: 0 },
+      end: { line: 2, column: 1, offset: 20 },
     });
     assertNode(item0.contents[0], 'text', {
-      start: { line: 1, column: 18, offset: 18 },
-      end: { line: 1, column: 19, offset: 19 },
+      start: { line: 1, column: 19, offset: 18 },
+      end: { line: 1, column: 20, offset: 19 },
     });
     const item1 = list.contents[1];
     assertNode(item1, 'ordered-list-item', {
-      start: { line: 2, column: 0, offset: 20 },
-      end: { line: 2, column: 8, offset: 28 },
+      start: { line: 2, column: 1, offset: 20 },
+      end: { line: 2, column: 9, offset: 28 },
     });
     assertNode(item1.contents[0], 'text', {
-      start: { line: 2, column: 5, offset: 25 },
-      end: { line: 2, column: 8, offset: 28 },
+      start: { line: 2, column: 6, offset: 25 },
+      end: { line: 2, column: 9, offset: 28 },
     });
   });
 });

--- a/test/tokenizer.js
+++ b/test/tokenizer.js
@@ -417,12 +417,12 @@ describe('Tokenizer', function () {
   it('tracks positions', function () {
     const t = new Tokenizer('1. foo');
     assertTok(t.next(), 'ol', '1. ', {
-      start: { line: 1, column: 0, offset: 0 },
-      end: { line: 1, column: 3, offset: 3 },
+      start: { line: 1, column: 1, offset: 0 },
+      end: { line: 1, column: 4, offset: 3 },
     });
     assertTok(t.next(), 'text', 'foo', {
-      start: { line: 1, column: 3, offset: 3 },
-      end: { line: 1, column: 6, offset: 6 },
+      start: { line: 1, column: 4, offset: 3 },
+      end: { line: 1, column: 7, offset: 6 },
     });
   });
 });


### PR DESCRIPTION
This matches ecmarkup, jsdom, and text editors.

We originally chose zero-based columns to match eslint, but it appears to be the odd one out.

This is a breaking change.