### PR TITLE
Version 6.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ecmarkdown",
-  "version": "5.1.2",
+  "version": "6.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecmarkdown",
-  "version": "5.1.2",
+  "version": "6.0.0",
   "description": "A compiler for \"Ecmarkdown\" algorithm shorthand into HTML.",
   "main": "dist/ecmarkdown.js",
   "scripts": {


### PR DESCRIPTION
Marked as major due to the inclusion of https://github.com/tc39/ecmarkdown/pull/79 and, arguably, https://github.com/tc39/ecmarkdown/pull/77.