### PR TITLE
Comments are not text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ecmarkdown",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecmarkdown",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "A compiler for \"Ecmarkdown\" algorithm shorthand into HTML.",
   "main": "dist/ecmarkdown.js",
   "scripts": {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -223,7 +223,7 @@ export class Parser {
 
         break;
       }
-      if (tok.name === 'opaqueTag') {
+      if (tok.name === 'opaqueTag' || tok.name === 'comment') {
         contents += wsChunk;
         break;
       }

--- a/test/parser.js
+++ b/test/parser.js
@@ -1,43 +1,76 @@
 'use strict';
 const assert = require('assert');
-const Tokenizer = require('../dist/tokenizer.js').Tokenizer;
-const Parser = require('../dist/parser.js').Parser;
+const { parseAlgorithm } = require('../');
 
 describe('Parser', function () {
-  function assertNode(node, name, location) {
+  function assertNodeLocation(node, name, location) {
     assert.equal(node.name, name);
     assert.deepEqual(node.location, location);
   }
+  function stripLocations(node) {
+    return JSON.parse(JSON.stringify(node, (k, v) => (k === 'location' ? undefined : v)));
+  }
   it('tracks positions', function () {
-    const tokenizer = new Tokenizer('  1. [id="thing"] a\n  2. b c');
-    const parser = new Parser(tokenizer);
-    const algorithm = parser.parseAlgorithm();
-    assertNode(algorithm, 'algorithm', {
+    const algorithm = parseAlgorithm('  1. [id="thing"] a\n  2. b c');
+    assertNodeLocation(algorithm, 'algorithm', {
       start: { line: 1, column: 1, offset: 0 },
       end: { line: 2, column: 9, offset: 28 },
     });
     const list = algorithm.contents;
-    assertNode(list, 'ol', {
+    assertNodeLocation(list, 'ol', {
       start: { line: 1, column: 1, offset: 0 },
       end: { line: 2, column: 9, offset: 28 },
     });
     const item0 = list.contents[0];
-    assertNode(item0, 'ordered-list-item', {
+    assertNodeLocation(item0, 'ordered-list-item', {
       start: { line: 1, column: 1, offset: 0 },
       end: { line: 2, column: 1, offset: 20 },
     });
-    assertNode(item0.contents[0], 'text', {
+    assertNodeLocation(item0.contents[0], 'text', {
       start: { line: 1, column: 19, offset: 18 },
       end: { line: 1, column: 20, offset: 19 },
     });
     const item1 = list.contents[1];
-    assertNode(item1, 'ordered-list-item', {
+    assertNodeLocation(item1, 'ordered-list-item', {
       start: { line: 2, column: 1, offset: 20 },
       end: { line: 2, column: 9, offset: 28 },
     });
-    assertNode(item1.contents[0], 'text', {
+    assertNodeLocation(item1.contents[0], 'text', {
       start: { line: 2, column: 6, offset: 25 },
       end: { line: 2, column: 9, offset: 28 },
+    });
+  });
+
+  it('does not consider comments to be text', function () {
+    const algorithm = stripLocations(parseAlgorithm('1. Foo. <!-- bar --> baz.'));
+    assert.deepStrictEqual(algorithm, {
+      name: 'algorithm',
+      contents: {
+        name: 'ol',
+        indent: 0,
+        start: 1,
+        contents: [
+          {
+            name: 'ordered-list-item',
+            id: null,
+            contents: [
+              {
+                contents: 'Foo. ',
+                name: 'text',
+              },
+              {
+                contents: '<!-- bar -->',
+                name: 'comment',
+              },
+              {
+                contents: ' baz.',
+                name: 'text',
+              },
+            ],
+            sublist: null,
+          },
+        ],
+      },
     });
   });
 });


### PR DESCRIPTION
Prior to this PR, `parseText` was greedy, such that ecmarkdown would parse `<!-- bar --> Foo.` as a comment followed by text but `Foo. <!-- bar -->` as a single text node containing `"Foo. <!-- bar -->"`.

Includes version bump, so please **rebase**, not squash.