### PR TITLE
support arbitrary attributes on list items, not just ids

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -54,6 +54,7 @@
     ],
     "no-underscore-dangle": "off",
     "no-constant-condition": "off",
+    "no-control-regex": "off",
     "camelcase": [
       "error",
       {

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Setup node
         uses: actions/setup-node@v2
+        with:
+          node-version: '12'
 
       - name: Install dependencies
         run: npm ci

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Lists are written as a series of lines, each starting with either a number, e.g.
 
 Lists can be nested. To do so, use any number of spaces to indent; as long as the number of spaces is consistent, list items will stay together in a nested list.
 
-List items can be given a id by putting `[id="something"]` at the start of the item, as in `1. [id="something"]`. This will generate a `<li>` element with an id property of `something`. This is used by Ecmarkup for referencing specific steps of Ecmarkdown algorithms.
+List items can be given arbitrary attributes by putting `[attr="something"]` at the start of the item, as in `1. [attr="something"]`. This will generate `<li attr="something">`. Multiple attributes are also supported as comma-seperated lists, as in `[attr1="a", attr2="b"]`.
 
 #### HTML Blocks
 

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -104,8 +104,8 @@ export class Emitter {
   }
 
   emitListItem(li: OrderedListItemNode | UnorderedListItemNode) {
-    let id = li.id === null ? '' : ` id="${li.id}"`;
-    this.str += `<li${id}>`;
+    const attrs = li.attrs.map(a => ` ${a.key}=${JSON.stringify(a.value)}`).join('');
+    this.str += `<li${attrs}>`;
     this.emitFragment(li.contents);
     if (li.sublist !== null) {
       if (li.sublist.name === 'ol') {

--- a/src/node-types.ts
+++ b/src/node-types.ts
@@ -83,8 +83,9 @@ export type OrderedListToken = {
   location: LocationRange;
 };
 
-export type IdToken = {
-  name: 'id';
+export type AttrToken = {
+  name: 'attr';
+  key: string;
   value: string;
   location: LocationRange;
 };
@@ -188,7 +189,7 @@ export type UnorderedListItemNode = {
   name: 'unordered-list-item';
   contents: FragmentNode[];
   sublist: ListNode | null;
-  id: string | null;
+  attrs: { key: string; value: string }[];
   location: LocationRange;
 };
 
@@ -196,7 +197,7 @@ export type OrderedListItemNode = {
   name: 'ordered-list-item';
   contents: FragmentNode[];
   sublist: ListNode | null;
-  id: string | null;
+  attrs: { key: string; value: string }[];
   location: LocationRange;
 };
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -114,7 +114,7 @@ export class Parser {
     // consume list token
     this._t.next();
 
-    const id = this._t.tryScanId();
+    const attrs = this._t.tryScanListItemAttributes();
 
     const contents: FragmentNode[] = this.parseFragment({ inList: true });
 
@@ -132,7 +132,7 @@ export class Parser {
 
     let name: 'ordered-list-item' | 'unordered-list-item' =
       kind === 'ol' ? 'ordered-list-item' : 'unordered-list-item';
-    return this.finish({ name, contents, sublist, id: id == null ? null : id.value });
+    return this.finish({ name, contents, sublist, attrs });
   }
 
   parseFragment(opts: ParseFragmentOpts): FragmentNode[];

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -148,7 +148,9 @@ export class Tokenizer {
       return [];
     }
 
-    const parts = match[0].matchAll(/([\w-]+) *= *("(?:[^"\\\x00-\x1F]|\\["\\/bfnrt]|\\u[a-fA-F]{4})*")/g);
+    const parts = match[0].matchAll(
+      /([\w-]+) *= *("(?:[^"\\\x00-\x1F]|\\["\\/bfnrt]|\\u[a-fA-F]{4})*")/g
+    );
     const tokens = [];
     let offset = 0;
     for (const { 0: part, 1: key, 2: value, index } of parts) {

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -1,8 +1,8 @@
-import type { Unlocated, Token, IdToken, Position } from './node-types';
+import type { Unlocated, Token, AttrToken, Position } from './node-types';
 
 const tagRegexp = /^<[/!]?(\w[\w-]*)(\s+[\w]+(\s*=\s*("[^"]*"|'[^']*'|[^><"'=``]+))?)*\s*>/;
 const commentRegexp = /^<!--[\w\W]*?-->/;
-const idRegexp = /^\[id="([\w-]+)"] /;
+const attrRegexp = /^\[ *[\w-]+ *= *"[^"\n]*" *(?:, *[\w-]+ *= *"[^"\n]*" *)*] /;
 const digitRegexp = /\d/;
 
 const opaqueTags = new Set(['emu-grammar', 'emu-production', 'pre', 'code', 'script', 'style']);
@@ -141,21 +141,36 @@ export class Tokenizer {
     return match[0];
   }
 
-  // ID tokens are only valid immediately after list tokens, so we let this be called by the parser.
-  tryScanId() {
-    const match = this.str.slice(this.pos).match(idRegexp);
+  // attribute tokens are only valid immediately after list tokens, so we let this be called by the parser.
+  tryScanListItemAttributes() {
+    const match = this.str.slice(this.pos).match(attrRegexp);
     if (!match) {
-      return null;
+      return [];
     }
 
-    const start = this.getLocation();
-
-    this.pos += match[0].length;
-
-    let token: Unlocated<IdToken> = { name: 'id', value: match[1] };
-    this.locate(token, start);
-
-    return token;
+    const parts = match[0].matchAll(/([\w-]+) *= *"([^"\n]*)"/g);
+    const tokens = [];
+    let offset = 0;
+    for (const part of parts) {
+      this.pos += part.index! - offset;
+      // updating column manually is kind of cheating, but whatever
+      // it only works because we know attributes can't contain linebreaks
+      // doing this allows us to avoid having tokens for the `,` and the ` ` between attributes
+      this.column += part.index! - offset;
+      const tokStart = this.getLocation();
+      const tok: Unlocated<AttrToken> = {
+        name: 'attr',
+        key: part[1],
+        value: part[2],
+      };
+      this.pos += part[0].length;
+      this.locate(tok, tokStart);
+      offset = part.index! + part[0].length;
+      tokens.push(tok);
+    }
+    this.pos += match[0].length - offset;
+    this.column += match[0].length - offset;
+    return tokens;
   }
 
   // Attempts to match any of the tokens at the given index of str
@@ -370,8 +385,8 @@ export class Tokenizer {
   // This is kind of an abuse of "asserts": we're not _asserting_ that `tok` has `location`, but rather arranging that this be so.
   // I don't think TS has a good way to model that, though.
   locate(tok: Unlocated<Token>, startPos: Position): asserts tok is Token;
-  locate(tok: Unlocated<IdToken>, startPos: Position): asserts tok is IdToken;
-  locate(tok: Unlocated<Token | IdToken>, startPos: Position) {
+  locate(tok: Unlocated<AttrToken>, startPos: Position): asserts tok is AttrToken;
+  locate(tok: Unlocated<Token | AttrToken>, startPos: Position) {
     if (tok.name === 'linebreak') {
       this.column = 1;
       ++this.line;

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "es2019",
     "module": "commonjs",
     "esModuleInterop": true,
     "strict": true,
@@ -8,5 +8,6 @@
     "forceConsistentCasingInFileNames": true,
     "outDir": "../dist",
     "declaration": true,
+    "lib": ["es2020"]
   }
 }

--- a/test/cases/list-attrs.ecmarkdown
+++ b/test/cases/list-attrs.ecmarkdown
@@ -1,0 +1,8 @@
+1. [id="foo"] Item
+1. Item
+1. Item
+  1. [attr="bar"] Item
+  1. Item
+1. Item
+  * Unordered item
+  * [thing-one="baz", thing-two="quux"] Unordered item

--- a/test/cases/list-attrs.html
+++ b/test/cases/list-attrs.html
@@ -2,13 +2,13 @@
   <li id="foo">Item</li>
   <li>Item</li>
   <li>Item<ol>
-      <li id="bar">Item</li>
+      <li attr="bar">Item</li>
       <li>Item</li>
     </ol>
   </li>
   <li>Item<ul>
       <li>Unordered item</li>
-      <li id="baz">Unordered item</li>
+      <li thing-one="baz" thing-two="quux">Unordered item</li>
     </ul>
   </li>
 </ol>

--- a/test/cases/list-id.ecmarkdown
+++ b/test/cases/list-id.ecmarkdown
@@ -1,8 +1,0 @@
-1. [id="foo"] Item
-1. Item
-1. Item
-  1. [id="bar"] Item
-  1. Item
-1. Item
-  * Unordered item
-  * [id="baz"] Unordered item

--- a/test/parser.js
+++ b/test/parser.js
@@ -58,7 +58,7 @@ describe('Parser', function () {
         contents: [
           {
             name: 'ordered-list-item',
-            id: null,
+            attrs: [],
             contents: [
               {
                 contents: 'Foo. ',


### PR DESCRIPTION
This is a breaking change (to the AST format), so while I was at it I bumped the minimum supported version of node to 12 so that I could use `matchAll`.