### PR TITLE
declare attribute type to contain location

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ecmarkdown",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ecmarkdown",
-      "version": "7.1.0",
+      "version": "7.2.0",
       "license": "WTFPL",
       "dependencies": {
         "escape-html": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecmarkdown",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "A compiler for \"Ecmarkdown\" algorithm shorthand into HTML.",
   "main": "dist/ecmarkdown.js",
   "scripts": {

--- a/src/node-types.ts
+++ b/src/node-types.ts
@@ -189,7 +189,7 @@ export type UnorderedListItemNode = {
   name: 'unordered-list-item';
   contents: FragmentNode[];
   sublist: ListNode | null;
-  attrs: { key: string; value: string }[];
+  attrs: { key: string; value: string; location: LocationRange }[];
   location: LocationRange;
 };
 
@@ -197,7 +197,7 @@ export type OrderedListItemNode = {
   name: 'ordered-list-item';
   contents: FragmentNode[];
   sublist: ListNode | null;
-  attrs: { key: string; value: string }[];
+  attrs: { key: string; value: string; location: LocationRange }[];
   location: LocationRange;
 };
 


### PR DESCRIPTION
Don't know why I left this out of https://github.com/tc39/ecmarkdown/pull/91. The location property does exist, it just wasn't declared.