### PR TITLE
Deindent rendered list item contents

### DIFF
--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -185,10 +185,10 @@ function unaryMemoize<K, V>(fn: (arg: K) => V, prepopulate: K[] = []) {
   const cache = new Map(prepopulate.map(arg => [arg, fn(arg)]));
   return (arg: K) => {
     let value = cache.get(arg);
-    if (!value) {
+    if (value === undefined && !cache.has(arg)) {
       value = fn(arg);
       cache.set(arg, value);
     }
-    return value;
+    return value as V;
   };
 }

--- a/src/node-types.ts
+++ b/src/node-types.ts
@@ -188,6 +188,7 @@ export type OrderedListNode = {
 export type UnorderedListItemNode = {
   name: 'unordered-list-item';
   contents: FragmentNode[];
+  contentsIndent: number;
   sublist: ListNode | null;
   attrs: { key: string; value: string; location: LocationRange }[];
   location: LocationRange;
@@ -196,6 +197,7 @@ export type UnorderedListItemNode = {
 export type OrderedListItemNode = {
   name: 'ordered-list-item';
   contents: FragmentNode[];
+  contentsIndent: number;
   sublist: ListNode | null;
   attrs: { key: string; value: string; location: LocationRange }[];
   location: LocationRange;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -79,12 +79,15 @@ export class Parser {
     const startTok = this._t.peek() as OrderedListToken | UnorderedListToken;
 
     let node: Unlocated<ListNode>;
+    let contentsIndent: number;
     if (startTok.name === 'ul') {
       const match = startTok.contents.match(/(\s*)\* /);
       node = { name: 'ul', indent: match![1].length, contents: [] };
+      contentsIndent = match![0].length;
     } else {
       const match = startTok.contents.match(/(\s*)([^.]+)\. /);
       node = { name: 'ol', indent: match![1].length, start: Number(match![2]), contents: [] };
+      contentsIndent = match![0].length;
     }
 
     while (true) {
@@ -101,15 +104,19 @@ export class Parser {
       }
 
       // @ts-ignore typescript is not smart enough to figure out that the types line up
-      node.contents.push(this.parseListItem(node.name, node.indent));
+      node.contents.push(this.parseListItem(node.name, node.indent, contentsIndent));
     }
 
     return this.finish(node);
   }
 
-  parseListItem(kind: 'ol', indent: number): OrderedListItemNode;
-  parseListItem(kind: 'ul', indent: number): UnorderedListItemNode;
-  parseListItem(kind: 'ol' | 'ul', indent: number): OrderedListItemNode | UnorderedListItemNode {
+  parseListItem(kind: 'ol', indent: number, contentsIndent: number): OrderedListItemNode;
+  parseListItem(kind: 'ul', indent: number, contentsIndent: number): UnorderedListItemNode;
+  parseListItem(
+    kind: 'ol' | 'ul',
+    indent: number,
+    contentsIndent: number
+  ): OrderedListItemNode | UnorderedListItemNode {
     this.pushPos();
     // consume list token
     this._t.next();
@@ -132,7 +139,7 @@ export class Parser {
 
     let name: 'ordered-list-item' | 'unordered-list-item' =
       kind === 'ol' ? 'ordered-list-item' : 'unordered-list-item';
-    return this.finish({ name, contents, sublist, attrs });
+    return this.finish({ name, contents, contentsIndent, sublist, attrs });
   }
 
   parseFragment(opts: ParseFragmentOpts): FragmentNode[];

--- a/test/cases/list-item-deindenting.raw.ecmarkdown
+++ b/test/cases/list-item-deindenting.raw.ecmarkdown
@@ -1,0 +1,22 @@
+1. Item 1
+  1. Item 1a
+     (multi-line)
+  1. Item 1b
+     (also multi-line)
+       ...and extra-indented
+1. Item 2
+    1. Item 2a
+       (multi-line)
+    1. Item 2b
+       (also multi-line)
+         ...and extra-indented
+1. Item 3
+  (multi-line but under-indented)
+1. Item 4
+  * unordered item
+    (multi-line)
+  * unordered item
+      (multi-line and extra-indented)
+    ...partially
+  * unordered item
+   (multi-line and under-indented)

--- a/test/cases/list-item-deindenting.raw.html
+++ b/test/cases/list-item-deindenting.raw.html
@@ -1,0 +1,12 @@
+<ol><li>Item 1<ol><li>Item 1a
+(multi-line)</li><li>Item 1b
+(also multi-line)
+  ...and extra-indented</li></ol></li><li>Item 2<ol><li>Item 2a
+(multi-line)</li><li>Item 2b
+(also multi-line)
+  ...and extra-indented</li></ol></li><li>Item 3
+(multi-line but under-indented)</li><li>Item 4<ul><li>unordered item
+(multi-line)</li><li>unordered item
+  (multi-line and extra-indented)
+...partially</li><li>unordered item
+(multi-line and under-indented)</li></ul></li></ol>

--- a/test/parser.js
+++ b/test/parser.js
@@ -59,6 +59,7 @@ describe('Parser', function () {
           {
             name: 'ordered-list-item',
             attrs: [],
+            contentsIndent: 3,
             contents: [
               {
                 contents: 'Foo. ',

--- a/test/run-cases.js
+++ b/test/run-cases.js
@@ -22,7 +22,7 @@ describe('baselines', () => {
         ? ecmarkdown.fragment
         : ecmarkdown.algorithm;
       let rawOutput = processor(input);
-      let output = beautify(rawOutput);
+      let output = file.endsWith('.raw.ecmarkdown') ? rawOutput + '\n' : beautify(rawOutput);
       let existing = fs.existsSync(snapshotFile) ? fs.readFileSync(snapshotFile, 'utf8') : null;
       if (shouldUpdate) {
         if (existing !== output) {


### PR DESCRIPTION
Line breaks in list items contents are preserved in output, but the indenting white space following them should be stripped. This will improve the rendering sought by https://github.com/tc39/ecmarkup/pull/513 .

**Exaggerated effects**
_ecmarkdown input_
```
1. Item 1
                      1. Item 2
                         Item 2 line 2
```

_output HTML_
```diff
 <ol><li>Item 1<ol><li>Item 2
-                         Item 2 line 2</li></ol></li></ol>
+Item 2 line 2</li></ol></li></ol>
```

_rendered output_
* Item 1
  * Item 2<br><s><ruby>·························<rt>25 removed spaces</rt></ruby></s>Item 2 line 2