### PR TITLE
Version 8.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ecmarkdown",
-  "version": "7.2.0",
+  "version": "8.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ecmarkdown",
-      "version": "7.2.0",
+      "version": "8.0.0",
       "license": "WTFPL",
       "dependencies": {
         "escape-html": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecmarkdown",
-  "version": "7.2.0",
+  "version": "8.0.0",
   "description": "A compiler for \"Ecmarkdown\" algorithm shorthand into HTML.",
   "main": "dist/ecmarkdown.js",
   "scripts": {


### PR DESCRIPTION
Breaking due to inclusion of https://github.com/tc39/ecmarkdown/pull/96 / https://github.com/tc39/ecmarkdown/pull/97, which require integration work in ecmarkup.