### PR TITLE
allow step attributes to be valueless

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ecmarkdown",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ecmarkdown",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "license": "WTFPL",
       "dependencies": {
         "escape-html": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecmarkdown",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "A compiler for \"Ecmarkdown\" algorithm shorthand into HTML.",
   "main": "dist/ecmarkdown.js",
   "scripts": {

--- a/test/cases/list-attrs.ecmarkdown
+++ b/test/cases/list-attrs.ecmarkdown
@@ -2,6 +2,7 @@
 1. Item
 1. Item
   1. [attr="bar"] Item
+  1. [no-value, with-empty="", with-value="val"] Item
   1. Item
 1. Item
   * Unordered item

--- a/test/cases/list-attrs.html
+++ b/test/cases/list-attrs.html
@@ -3,6 +3,7 @@
   <li>Item</li>
   <li>Item<ol>
       <li attr="bar">Item</li>
+      <li no-value with-empty with-value="val">Item</li>
       <li>Item</li>
     </ol>
   </li>

--- a/test/errors.js
+++ b/test/errors.js
@@ -68,4 +68,13 @@ ${M}      * b
       'Unexpected token parabreak; expected EOF'
     );
   });
+
+  it('bad step attributes', function () {
+    assertAlgError(
+      positioned`
+      1. ${M}[x y]
+    `,
+      'could not parse attributes for step'
+    );
+  });
 });

--- a/test/parser.js
+++ b/test/parser.js
@@ -4,14 +4,16 @@ const { parseAlgorithm, parseFragment } = require('../');
 
 describe('Parser', function () {
   it('tracks positions in algorithms', function () {
-    const baseSource = '  1. [id="thing"] a\n  2. b c\n    <figure>text</figure>';
+    const baseSource = '  1. [id="thing", other] a\n  2. b c\n    <figure>text</figure>';
     const assertNodeLocation = makeAssertLocation(baseSource);
     const algorithm = parseAlgorithm(baseSource);
     assertNodeLocation(algorithm, baseSource);
     const list = algorithm.contents;
-    assertNodeLocation(list, '  1. [id="thing"] a\n  2. b c\n    <figure>text</figure>');
+    assertNodeLocation(list, '  1. [id="thing", other] a\n  2. b c\n    <figure>text</figure>');
     const item0 = list.contents[0];
-    assertNodeLocation(item0, '  1. [id="thing"] a\n');
+    assertNodeLocation(item0, '  1. [id="thing", other] a\n');
+    assertNodeLocation(item0.attrs[0], 'id="thing"');
+    assertNodeLocation(item0.attrs[1], 'other');
     assertNodeLocation(item0.contents[0], 'a');
     const item1 = list.contents[1];
     assertNodeLocation(item1, '  2. b c\n    <figure>text</figure>');


### PR DESCRIPTION
Towards new attributes like https://github.com/tc39/proposal-import-attributes/pull/133.

Also enforces that steps which start with `[` do in fact start with attributes, instead of falling back to treating that as prose. This is arguably a breaking change, but I don't see a valid reason to start a line with `[`, so I think this is fine.

Includes version bump.